### PR TITLE
Add Arches 8.0 compatibility fixes for resource models

### DIFF
--- a/graphs/resource_models/Activity.json
+++ b/graphs/resource_models/Activity.json
@@ -3215,7 +3215,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "fe8a0957-48ab-11ee-8a8d-11afefc4bff7",
+                    "node_id": "e564854e-df38-4a55-ba74-e9ddf5efd7d9",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3237,7 +3237,7 @@
                     "label": {
                         "en": "Statement Type"
                     },
-                    "node_id": "fe8a0959-48ab-11ee-8a8d-11afefc4bff7",
+                    "node_id": "6ede0d98-25f8-4f54-b973-bdbe17b378be",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -3266,7 +3266,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "fe8a095d-48ab-11ee-8a8d-11afefc4bff7",
+                    "node_id": "e563aad7-984d-4284-ad7d-7f7c3c2a64de",
                     "sortorder": 4,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3288,7 +3288,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "fe8a095e-48ab-11ee-8a8d-11afefc4bff7",
+                    "node_id": "6e7c510b-6917-4306-aea2-d1a0721947e6",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -3310,7 +3310,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "fe8a095f-48ab-11ee-8a8d-11afefc4bff7",
+                    "node_id": "5cbb67cd-491d-4e22-93bf-384b60cec6cb",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -3332,7 +3332,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "fe8a0975-48ab-11ee-8a8d-11afefc4bff7",
+                    "node_id": "0cf72eef-4457-495f-b4dc-0d8dc53bb491",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -3361,7 +3361,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "fe8a0979-48ab-11ee-8a8d-11afefc4bff7",
+                    "node_id": "47668aa4-4200-409b-a673-589831360534",
                     "sortorder": null,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3390,7 +3390,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "fe8a0980-48ab-11ee-8a8d-11afefc4bff7",
+                    "node_id": "e4852a95-d2a9-4cdb-ad34-28e75d235b67",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3412,7 +3412,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "fe8a0985-48ab-11ee-8a8d-11afefc4bff7",
+                    "node_id": "9e290676-fa65-4f67-b525-beb33b6f35aa",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -3739,7 +3739,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "70e1fb98-4bb2-11ee-8a8d-11afefc4bff7",
+                    "node_id": "041a10cb-eb73-43a1-a7a4-77bc4a731e83",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -3768,7 +3768,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "70e1fb9a-4bb2-11ee-8a8d-11afefc4bff7",
+                    "node_id": "1f2e5a1c-1e10-4142-a7f7-9c6c0f173fb1",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3797,7 +3797,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "70e1fb9b-4bb2-11ee-8a8d-11afefc4bff7",
+                    "node_id": "78f7ea7c-7ac3-4ed5-9e99-e37f7bc77f2a",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3819,7 +3819,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "70e1fb9d-4bb2-11ee-8a8d-11afefc4bff7",
+                    "node_id": "8baf0833-b1e9-4df4-b6fd-1fcd1e34cdd8",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4797,9 +4797,7 @@
                 {
                     "card_id": "c47f4edb-ddba-11eb-ba14-0a9473e82189",
                     "config": {
-                        "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -4901,7 +4899,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "70e1fb9f-4bb2-11ee-8a8d-11afefc4bff7",
+                    "node_id": "db657ba7-8953-4f2b-af44-9de0df369248",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4930,7 +4928,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "70e1fb73-4bb2-11ee-8a8d-11afefc4bff7",
+                    "node_id": "dc52870d-d0b2-487c-8555-22a3329e89e7",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4952,7 +4950,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "70e1fb74-4bb2-11ee-8a8d-11afefc4bff7",
+                    "node_id": "6b5e5043-a908-4222-a2f8-173f2f7e08cd",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -4981,7 +4979,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "70e1fb75-4bb2-11ee-8a8d-11afefc4bff7",
+                    "node_id": "90d966d2-1f30-4938-9dcf-ee64a2ea9ad3",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -9356,6 +9354,168 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P141i_was_assigned_by",
                     "rangenode_id": "fe8a0954-48ab-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "70e1fb72-4bb2-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "e771e722-6ac7-42be-a939-c664c283bbb2",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "dc52870d-d0b2-487c-8555-22a3329e89e7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "70e1fb72-4bb2-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "28c26c07-6085-4fd7-863b-1260182768f0",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "6b5e5043-a908-4222-a2f8-173f2f7e08cd"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "70e1fb72-4bb2-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "84dbf7b1-15f4-4ca7-9966-9f8cec121a15",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "90d966d2-1f30-4938-9dcf-ee64a2ea9ad3"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "70e1fb72-4bb2-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "7c52881a-bf33-4785-8bd0-c789308b19c8",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "db657ba7-8953-4f2b-af44-9de0df369248"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "70e1fb95-4bb2-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "79635017-bf13-4fe4-b96b-de6cfc13f057",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "041a10cb-eb73-43a1-a7a4-77bc4a731e83"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "70e1fb95-4bb2-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "ee14326e-403b-4877-acc3-118486cb72cc",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "1f2e5a1c-1e10-4142-a7f7-9c6c0f173fb1"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "70e1fb95-4bb2-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "50e6bb70-ca64-4578-99d7-dd21dcd164c4",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "78f7ea7c-7ac3-4ed5-9e99-e37f7bc77f2a"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "70e1fb95-4bb2-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "c8a34762-02a0-4e87-ac12-8132f6c40239",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "8baf0833-b1e9-4df4-b6fd-1fcd1e34cdd8"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "d41e9444-c2c2-4c98-99c0-a560f9c3d64f",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "0cf72eef-4457-495f-b4dc-0d8dc53bb491"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "2e96b1a6-eab7-43cc-aa79-3567e0350fd7",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "47668aa4-4200-409b-a673-589831360534"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "915bfb54-4bd2-4888-ab9c-5eae590e7ec9",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "e4852a95-d2a9-4cdb-ad34-28e75d235b67"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "22a7ec43-6e4f-43f4-af40-4a3149889c0a",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "9e290676-fa65-4f67-b525-beb33b6f35aa"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "c813538d-746a-432b-a371-1a408653fbed",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "e564854e-df38-4a55-ba74-e9ddf5efd7d9"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "cdd4d3fe-bbb5-450e-a42d-94ee45084031",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "6e7c510b-6917-4306-aea2-d1a0721947e6"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "0efdda43-4fcc-43e6-a5bc-9cdbd90e3650",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "e563aad7-984d-4284-ad7d-7f7c3c2a64de"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "982966e7-88f9-49e0-a318-6c84453b40e6",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "6ede0d98-25f8-4f54-b973-bdbe17b378be"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fe8a0959-48ab-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "c4af8593-fe64-4ca9-bcb3-b401ae86b29e",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "5cbb67cd-491d-4e22-93bf-384b60cec6cb"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "6ede0d98-25f8-4f54-b973-bdbe17b378be",
+                    "edgeid": "37537bf4-cf17-4e7b-8107-f9d5466c3a66",
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "fe8a095f-48ab-11ee-8a8d-11afefc4bff7"
                 }
             ],
             "functions_x_graphs": [
@@ -11633,7 +11793,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_name_type",
+                    "alias": "data_assignment_name_type_1",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -11647,7 +11807,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_name_type",
+                    "name": "data_assignment_name_type_1",
                     "nodegroup_id": "70e1fb72-4bb2-11ee-8a8d-11afefc4bff7",
                     "nodeid": "70e1fb74-4bb2-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -12440,7 +12600,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_name_language",
+                    "alias": "data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -12454,7 +12614,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_name_language",
+                    "name": "data_assignment_statement_name_language_1",
                     "nodegroup_id": "70e1fb95-4bb2-11ee-8a8d-11afefc4bff7",
                     "nodeid": "70e1fb98-4bb2-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -12486,7 +12646,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_name_label",
+                    "alias": "data_assignment_statement_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -12498,7 +12658,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_name_label",
+                    "name": "data_assignment_statement_name_label_1",
                     "nodegroup_id": "70e1fb95-4bb2-11ee-8a8d-11afefc4bff7",
                     "nodeid": "70e1fb9a-4bb2-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -14297,7 +14457,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_content",
+                    "alias": "identifier_data_assignment_statement_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -14309,7 +14469,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_content",
+                    "name": "identifier_data_assignment_statement_content_1",
                     "nodegroup_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
                     "nodeid": "fe8a0957-48ab-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -14341,7 +14501,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_type",
+                    "alias": "identifier_data_assignment_statement_type_1",
                     "config": {
                         "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
                     },
@@ -14355,7 +14515,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_type",
+                    "name": "identifier_data_assignment_statement_type_1",
                     "nodegroup_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
                     "nodeid": "fe8a0959-48ab-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -14410,7 +14570,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_label",
+                    "alias": "identifier_data_assignment_statement_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -14422,7 +14582,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_label",
+                    "name": "identifier_data_assignment_statement_label_1",
                     "nodegroup_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
                     "nodeid": "fe8a095d-48ab-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -14431,7 +14591,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_language",
+                    "alias": "identifier_data_assignment_statement_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -14445,7 +14605,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_language",
+                    "name": "identifier_data_assignment_statement_language_1",
                     "nodegroup_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
                     "nodeid": "fe8a095e-48ab-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -14454,7 +14614,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_type_metatype",
+                    "alias": "identifier_data_assignment_statement_type_metatype_1",
                     "config": {
                         "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
                     },
@@ -14468,7 +14628,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_type_metatype",
+                    "name": "identifier_data_assignment_statement_type_metatype_1",
                     "nodegroup_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
                     "nodeid": "fe8a095f-48ab-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -14938,7 +15098,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_language",
+                    "alias": "identifier_data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -14952,7 +15112,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_language",
+                    "name": "identifier_data_assignment_statement_name_language_1",
                     "nodegroup_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
                     "nodeid": "fe8a0975-48ab-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -15026,7 +15186,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_label",
+                    "alias": "identifier_data_assignment_statement_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -15038,7 +15198,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_label",
+                    "name": "identifier_data_assignment_statement_name_label_1",
                     "nodegroup_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
                     "nodeid": "fe8a0979-48ab-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -15179,7 +15339,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_content",
+                    "alias": "identifier_data_assignment_statement_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -15191,7 +15351,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_content",
+                    "name": "identifier_data_assignment_statement_name_content_1",
                     "nodegroup_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
                     "nodeid": "fe8a0980-48ab-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -15299,7 +15459,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_type",
+                    "alias": "identifier_data_assignment_statement_name_type_1",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -15313,7 +15473,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_type",
+                    "name": "identifier_data_assignment_statement_name_type_1",
                     "nodegroup_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
                     "nodeid": "fe8a0985-48ab-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -15339,6 +15499,381 @@
                     "name": "identifier_data_assignment_timespan_statement_metatype",
                     "nodegroup_id": "fe8a0951-48ab-11ee-8a8d-11afefc4bff7",
                     "nodeid": "fe8a0986-48ab-11ee-8a8d-11afefc4bff7",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_label_1",
+                    "nodegroup_id": "70e1fb72-4bb2-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "dc52870d-d0b2-487c-8555-22a3329e89e7",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_type",
+                    "nodegroup_id": "70e1fb72-4bb2-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "6b5e5043-a908-4222-a2f8-173f2f7e08cd",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_content_1",
+                    "nodegroup_id": "70e1fb72-4bb2-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "90d966d2-1f30-4938-9dcf-ee64a2ea9ad3",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_language",
+                    "nodegroup_id": "70e1fb95-4bb2-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "041a10cb-eb73-43a1-a7a4-77bc4a731e83",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_label",
+                    "nodegroup_id": "70e1fb95-4bb2-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "1f2e5a1c-1e10-4142-a7f7-9c6c0f173fb1",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_content_1",
+                    "nodegroup_id": "70e1fb95-4bb2-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "78f7ea7c-7ac3-4ed5-9e99-e37f7bc77f2a",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_type_1",
+                    "nodegroup_id": "70e1fb95-4bb2-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "8baf0833-b1e9-4df4-b6fd-1fcd1e34cdd8",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_language_1",
+                    "nodegroup_id": "70e1fb72-4bb2-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "db657ba7-8953-4f2b-af44-9de0df369248",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_content",
+                    "nodegroup_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "e564854e-df38-4a55-ba74-e9ddf5efd7d9",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_type",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_type",
+                    "nodegroup_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "6ede0d98-25f8-4f54-b973-bdbe17b378be",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_label",
+                    "nodegroup_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "e563aad7-984d-4284-ad7d-7f7c3c2a64de",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_language",
+                    "nodegroup_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "6e7c510b-6917-4306-aea2-d1a0721947e6",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_type_metatype",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_type_metatype",
+                    "nodegroup_id": "fe8a097a-48ab-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "5cbb67cd-491d-4e22-93bf-384b60cec6cb",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_language",
+                    "nodegroup_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "0cf72eef-4457-495f-b4dc-0d8dc53bb491",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_label",
+                    "nodegroup_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "47668aa4-4200-409b-a673-589831360534",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_content",
+                    "nodegroup_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "e4852a95-d2a9-4cdb-ad34-28e75d235b67",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "734d1558-bfad-11ea-a62b-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_type",
+                    "nodegroup_id": "fe8a0970-48ab-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "9e290676-fa65-4f67-b525-beb33b6f35aa",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,

--- a/graphs/resource_models/Digital Object.json
+++ b/graphs/resource_models/Digital Object.json
@@ -3640,9 +3640,7 @@
                 {
                     "card_id": "75511a7b-4643-11ee-8a8d-11afefc4bff7",
                     "config": {
-                        "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -4640,7 +4638,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "85e6e1a1-4e1b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "9a7fa006-797f-48bf-be19-d3465c9c75b9",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4662,7 +4660,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "85e6e199-4e1b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "1b2c4d00-2a93-4ab8-86a8-233b4fd525f0",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4691,7 +4689,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "85e6e194-4e1b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "efa5b380-b47f-4fd7-bba1-f4568de6d17f",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4720,7 +4718,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "85e6e18e-4e1b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "222e5d4a-72e5-4963-87ee-fc0b5d36b55f",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -13676,6 +13674,42 @@
                     "name": null,
                     "ontologyproperty": "https://linked.art/ns/terms/access_point",
                     "rangenode_id": "fd9b0496-4b31-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "85e6e182-4e1b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "63937926-a5fd-4fc1-9f26-2d222f216290",
+                    "graph_id": "0044f7da-b4b6-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "222e5d4a-72e5-4963-87ee-fc0b5d36b55f"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "85e6e182-4e1b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "39b19198-4710-4a21-bbc6-c9c00ce24378",
+                    "graph_id": "0044f7da-b4b6-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "1b2c4d00-2a93-4ab8-86a8-233b4fd525f0"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "85e6e182-4e1b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "9f6403fe-f157-403e-aaac-8b96dd9be1e5",
+                    "graph_id": "0044f7da-b4b6-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "efa5b380-b47f-4fd7-bba1-f4568de6d17f"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "85e6e182-4e1b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "e4e6c634-5d54-4673-aff6-b1b8661b5d99",
+                    "graph_id": "0044f7da-b4b6-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "9a7fa006-797f-48bf-be19-d3465c9c75b9"
                 }
             ],
             "functions_x_graphs": [
@@ -15592,7 +15626,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "digital_service_identifier_data_assignment_statement_name_label",
+                    "alias": "digital_service_identifier_data_assignment_statement_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -15604,7 +15638,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "digital_service_identifier_data_assignment_statement_name_label",
+                    "name": "digital_service_identifier_data_assignment_statement_name_label_1",
                     "nodegroup_id": "85e6e182-4e1b-11ee-8a8d-11afefc4bff7",
                     "nodeid": "85e6e18e-4e1b-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -15835,7 +15869,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "digital_service_identifier_data_assignment_statement_name_type",
+                    "alias": "digital_service_identifier_data_assignment_statement_name_type_1",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -15849,7 +15883,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "digital_service_identifier_data_assignment_statement_name_type",
+                    "name": "digital_service_identifier_data_assignment_statement_name_type_1",
                     "nodegroup_id": "85e6e182-4e1b-11ee-8a8d-11afefc4bff7",
                     "nodeid": "85e6e199-4e1b-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -22850,6 +22884,94 @@
                     "nodeid": "fd9b0496-4b31-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.ics.forth.gr/isl/CRMdig/D1_Digital_Object",
                     "parentproperty": "https://linked.art/ns/terms/access_point",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "digital_service_identifier_data_assignment_statement_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "0044f7da-b4b6-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "digital_service_identifier_data_assignment_statement_name_label",
+                    "nodegroup_id": "85e6e182-4e1b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "222e5d4a-72e5-4963-87ee-fc0b5d36b55f",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "digital_service_identifier_data_assignment_statement_name_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "0044f7da-b4b6-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "digital_service_identifier_data_assignment_statement_name_content_1",
+                    "nodegroup_id": "85e6e182-4e1b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "efa5b380-b47f-4fd7-bba1-f4568de6d17f",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "digital_service_identifier_data_assignment_statement_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "0044f7da-b4b6-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "digital_service_identifier_data_assignment_statement_name_type",
+                    "nodegroup_id": "85e6e182-4e1b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "1b2c4d00-2a93-4ab8-86a8-233b4fd525f0",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "digital_service_identifier_data_assignment_statement_name_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "0044f7da-b4b6-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "digital_service_identifier_data_assignment_statement_name_language_1",
+                    "nodegroup_id": "85e6e182-4e1b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "9a7fa006-797f-48bf-be19-d3465c9c75b9",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 }

--- a/graphs/resource_models/Event.json
+++ b/graphs/resource_models/Event.json
@@ -1835,9 +1835,7 @@
                 {
                     "card_id": "3228438f-465b-11ee-8a8d-11afefc4bff7",
                     "config": {
-                        "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],

--- a/graphs/resource_models/Group.json
+++ b/graphs/resource_models/Group.json
@@ -4087,7 +4087,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "5db50c1f-2013-11ee-9071-214dbb482912",
+                    "node_id": "0e97b4fb-9e50-4f9b-8c3f-bdd7707a66e5",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4109,7 +4109,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "5db50c1e-2013-11ee-9071-214dbb482912",
+                    "node_id": "8a75bd7f-a8d1-4a73-9530-51a9b2739c53",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -4138,7 +4138,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "5db50c1d-2013-11ee-9071-214dbb482912",
+                    "node_id": "3f48772f-bce8-4b2a-b4b9-daf9eb966f94",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4160,7 +4160,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "5db50c49-2013-11ee-9071-214dbb482912",
+                    "node_id": "83c7aa32-a526-4171-8374-fcc9db570504",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4479,7 +4479,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "4907e626-0396-11ee-8f04-cd21e680a247",
+                    "node_id": "a18a76f6-4cab-4d71-a7fe-6cb8bfa81949",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4501,7 +4501,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "23569c24-0396-11ee-8f04-cd21e680a247",
+                    "node_id": "863ebba4-0396-4854-8a7c-aff02e8f6753",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4523,7 +4523,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "366561ce-0396-11ee-8f04-cd21e680a247",
+                    "node_id": "6d8102a8-9459-42b6-bb14-1e7f5cf3abed",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4581,7 +4581,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "12afc9cc-0396-11ee-8f04-cd21e680a247",
+                    "node_id": "fef97b7d-27b2-44ac-be72-1653d2d153eb",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -6752,9 +6752,7 @@
                 {
                     "card_id": "5bc661a8-bb18-11ea-85a6-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -12070,7 +12068,7 @@
                     "label": {
                         "en": "Statement Type"
                     },
-                    "node_id": "5db50c2f-2013-11ee-9071-214dbb482912",
+                    "node_id": "97af5a53-4f96-4e80-9e59-c94763357512",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -12092,7 +12090,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "5db50c37-2013-11ee-9071-214dbb482912",
+                    "node_id": "240a1f2b-ccaf-4db0-871a-50dc8871bfce",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -12121,7 +12119,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "5db50c3a-2013-11ee-9071-214dbb482912",
+                    "node_id": "b8ea3608-4769-443b-b8a2-b56950d8993a",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -12150,7 +12148,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "5db50c48-2013-11ee-9071-214dbb482912",
+                    "node_id": "0478dff8-295f-4972-b1e5-cbc39fd547ce",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -12172,7 +12170,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "5db50c3d-2013-11ee-9071-214dbb482912",
+                    "node_id": "9a638f89-9873-40e0-a985-06431d6f3eeb",
                     "sortorder": 4,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -13828,7 +13826,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "5db50c42-2013-11ee-9071-214dbb482912",
+                    "node_id": "52b724ef-337c-4394-8258-52332efd1202",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -13857,7 +13855,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "5db50c45-2013-11ee-9071-214dbb482912",
+                    "node_id": "c1d001ff-4679-4831-9d19-39fee35f0c7b",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -13879,7 +13877,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "5db50c47-2013-11ee-9071-214dbb482912",
+                    "node_id": "3b4da7d2-d545-4a02-a036-60d349b206d3",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -13908,7 +13906,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "5db50c44-2013-11ee-9071-214dbb482912",
+                    "node_id": "789b00ba-2580-44b8-a841-cd7a013418bf",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -18722,6 +18720,168 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "rangenode_id": "fde0f040-4b0f-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "00555c1a-0396-11ee-8f04-cd21e680a247",
+                    "edgeid": "77ded06f-9d2a-4e3f-afeb-c9e8c49b0b85",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "fef97b7d-27b2-44ac-be72-1653d2d153eb"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "00555c1a-0396-11ee-8f04-cd21e680a247",
+                    "edgeid": "af1916a2-4345-4eb2-8e9f-f2db9695cdca",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "863ebba4-0396-4854-8a7c-aff02e8f6753"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "00555c1a-0396-11ee-8f04-cd21e680a247",
+                    "edgeid": "287f3b36-849c-486d-afd3-fbf1a0510978",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "6d8102a8-9459-42b6-bb14-1e7f5cf3abed"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "00555c1a-0396-11ee-8f04-cd21e680a247",
+                    "edgeid": "2d990527-4fc4-4e4c-a96a-e7a6f6d9df19",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "a18a76f6-4cab-4d71-a7fe-6cb8bfa81949"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c1c-2013-11ee-9071-214dbb482912",
+                    "edgeid": "fcd84b82-dc8a-48f8-8753-8d5d147916e5",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "3f48772f-bce8-4b2a-b4b9-daf9eb966f94"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c1c-2013-11ee-9071-214dbb482912",
+                    "edgeid": "ae1fd8a0-c55c-4d72-a7f6-d9f31d3df339",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "8a75bd7f-a8d1-4a73-9530-51a9b2739c53"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c1c-2013-11ee-9071-214dbb482912",
+                    "edgeid": "ea1f72f1-1be9-47dc-badd-6402ac2ed5ab",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "0e97b4fb-9e50-4f9b-8c3f-bdd7707a66e5"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c1c-2013-11ee-9071-214dbb482912",
+                    "edgeid": "a49326a2-d5ae-41c2-a04c-b53f9c365f22",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "83c7aa32-a526-4171-8374-fcc9db570504"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c2d-2013-11ee-9071-214dbb482912",
+                    "edgeid": "f0a04103-8906-457a-9ce3-70056ac7792d",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "240a1f2b-ccaf-4db0-871a-50dc8871bfce"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c2d-2013-11ee-9071-214dbb482912",
+                    "edgeid": "f825b716-2664-4afe-9530-a2def7a8b59f",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "b8ea3608-4769-443b-b8a2-b56950d8993a"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c2d-2013-11ee-9071-214dbb482912",
+                    "edgeid": "65d08fc0-24a9-4b99-9f76-82182468f78b",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "97af5a53-4f96-4e80-9e59-c94763357512"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c2f-2013-11ee-9071-214dbb482912",
+                    "edgeid": "769f7140-e55e-4efa-9270-4d1b83c7e2cd",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "9a638f89-9873-40e0-a985-06431d6f3eeb"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "97af5a53-4f96-4e80-9e59-c94763357512",
+                    "edgeid": "d098bb76-4f69-4061-ae1f-c4581cfffeb8",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "5db50c3d-2013-11ee-9071-214dbb482912"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c3f-2013-11ee-9071-214dbb482912",
+                    "edgeid": "1094aa6a-0bb5-408c-9186-fb2c7e32eda7",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "52b724ef-337c-4394-8258-52332efd1202"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c3f-2013-11ee-9071-214dbb482912",
+                    "edgeid": "a2885c6f-7822-4aab-9095-c6a3baca072f",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "789b00ba-2580-44b8-a841-cd7a013418bf"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c3f-2013-11ee-9071-214dbb482912",
+                    "edgeid": "f22ac417-8f22-4a34-a6d7-4a5a4a7e852a",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "c1d001ff-4679-4831-9d19-39fee35f0c7b"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c3f-2013-11ee-9071-214dbb482912",
+                    "edgeid": "ca067d5c-5fbd-4afe-8d23-5f3facb23fda",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "3b4da7d2-d545-4a02-a036-60d349b206d3"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5db50c2d-2013-11ee-9071-214dbb482912",
+                    "edgeid": "6eee7e37-10fd-4a85-8922-757dfd5e5179",
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "0478dff8-295f-4972-b1e5-cbc39fd547ce"
                 }
             ],
             "functions_x_graphs": [
@@ -23895,7 +24055,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_name_label",
+                    "alias": "data_assignment_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -23907,7 +24067,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_name_label",
+                    "name": "data_assignment_name_label_1",
                     "nodegroup_id": "5db50c1c-2013-11ee-9071-214dbb482912",
                     "nodeid": "5db50c1d-2013-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -23939,7 +24099,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_name_content",
+                    "alias": "data_assignment_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -23951,7 +24111,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_name_content",
+                    "name": "data_assignment_name_content_1",
                     "nodegroup_id": "5db50c1c-2013-11ee-9071-214dbb482912",
                     "nodeid": "5db50c1f-2013-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -24480,7 +24640,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_language",
+                    "alias": "data_assignment_statement_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -24494,7 +24654,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_language",
+                    "name": "data_assignment_statement_language_1",
                     "nodegroup_id": "5db50c2d-2013-11ee-9071-214dbb482912",
                     "nodeid": "5db50c37-2013-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -24723,7 +24883,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_name_language",
+                    "alias": "data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -24737,7 +24897,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_name_language",
+                    "name": "data_assignment_statement_name_language_1",
                     "nodegroup_id": "5db50c3f-2013-11ee-9071-214dbb482912",
                     "nodeid": "5db50c42-2013-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -24834,7 +24994,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_name_type",
+                    "alias": "data_assignment_statement_name_type_1",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -24848,7 +25008,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_name_type",
+                    "name": "data_assignment_statement_name_type_1",
                     "nodegroup_id": "5db50c3f-2013-11ee-9071-214dbb482912",
                     "nodeid": "5db50c47-2013-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -24857,7 +25017,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_content",
+                    "alias": "data_assignment_statement_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -24869,7 +25029,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_content",
+                    "name": "data_assignment_statement_content_1",
                     "nodegroup_id": "5db50c2d-2013-11ee-9071-214dbb482912",
                     "nodeid": "5db50c48-2013-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -31169,6 +31329,381 @@
                     "nodeid": "fde0f040-4b0f-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "group_formation_identifier_data_assignment_timespan_statement_name_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "group_formation_identifier_data_assignment_timespan_statement_name_content_1",
+                    "nodegroup_id": "00555c1a-0396-11ee-8f04-cd21e680a247",
+                    "nodeid": "fef97b7d-27b2-44ac-be72-1653d2d153eb",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "group_formation_identifier_data_assignment_timespan_statement_name_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "group_formation_identifier_data_assignment_timespan_statement_name_language_1",
+                    "nodegroup_id": "00555c1a-0396-11ee-8f04-cd21e680a247",
+                    "nodeid": "863ebba4-0396-4854-8a7c-aff02e8f6753",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "group_formation_identifier_data_assignment_timespan_statement_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "group_formation_identifier_data_assignment_timespan_statement_name_type_1",
+                    "nodegroup_id": "00555c1a-0396-11ee-8f04-cd21e680a247",
+                    "nodeid": "6d8102a8-9459-42b6-bb14-1e7f5cf3abed",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "group_formation_identifier_data_assignment_timespan_statement_name_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "group_formation_identifier_data_assignment_timespan_statement_name_label_1",
+                    "nodegroup_id": "00555c1a-0396-11ee-8f04-cd21e680a247",
+                    "nodeid": "a18a76f6-4cab-4d71-a7fe-6cb8bfa81949",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_label",
+                    "nodegroup_id": "5db50c1c-2013-11ee-9071-214dbb482912",
+                    "nodeid": "3f48772f-bce8-4b2a-b4b9-daf9eb966f94",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_type_1",
+                    "nodegroup_id": "5db50c1c-2013-11ee-9071-214dbb482912",
+                    "nodeid": "8a75bd7f-a8d1-4a73-9530-51a9b2739c53",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_content",
+                    "nodegroup_id": "5db50c1c-2013-11ee-9071-214dbb482912",
+                    "nodeid": "0e97b4fb-9e50-4f9b-8c3f-bdd7707a66e5",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_type_1",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_type_1",
+                    "nodegroup_id": "5db50c2d-2013-11ee-9071-214dbb482912",
+                    "nodeid": "97af5a53-4f96-4e80-9e59-c94763357512",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_language",
+                    "nodegroup_id": "5db50c2d-2013-11ee-9071-214dbb482912",
+                    "nodeid": "240a1f2b-ccaf-4db0-871a-50dc8871bfce",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_label_1",
+                    "nodegroup_id": "5db50c2d-2013-11ee-9071-214dbb482912",
+                    "nodeid": "b8ea3608-4769-443b-b8a2-b56950d8993a",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_type_metatype_1",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_type_metatype_1",
+                    "nodegroup_id": "5db50c2d-2013-11ee-9071-214dbb482912",
+                    "nodeid": "9a638f89-9873-40e0-a985-06431d6f3eeb",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_language",
+                    "nodegroup_id": "5db50c3f-2013-11ee-9071-214dbb482912",
+                    "nodeid": "52b724ef-337c-4394-8258-52332efd1202",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_label_1",
+                    "nodegroup_id": "5db50c3f-2013-11ee-9071-214dbb482912",
+                    "nodeid": "789b00ba-2580-44b8-a841-cd7a013418bf",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_content_1",
+                    "nodegroup_id": "5db50c3f-2013-11ee-9071-214dbb482912",
+                    "nodeid": "c1d001ff-4679-4831-9d19-39fee35f0c7b",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_type",
+                    "nodegroup_id": "5db50c3f-2013-11ee-9071-214dbb482912",
+                    "nodeid": "3b4da7d2-d545-4a02-a036-60d349b206d3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_content",
+                    "nodegroup_id": "5db50c2d-2013-11ee-9071-214dbb482912",
+                    "nodeid": "0478dff8-295f-4972-b1e5-cbc39fd547ce",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_language_1",
+                    "nodegroup_id": "5db50c1c-2013-11ee-9071-214dbb482912",
+                    "nodeid": "83c7aa32-a526-4171-8374-fcc9db570504",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 }

--- a/graphs/resource_models/Person.json
+++ b/graphs/resource_models/Person.json
@@ -4416,7 +4416,7 @@
                     "label": {
                         "en": "Type of Data Assignment"
                     },
-                    "node_id": "7bc91414-da2d-11ed-8e35-713b6788f6a4",
+                    "node_id": "5d6ec944-9913-4aa6-b151-0e395caf019f",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4555,7 +4555,7 @@
                     "label": {
                         "en": "Identifier Label"
                     },
-                    "node_id": "ad575d54-da2a-11ed-8e35-713b6788f6a4",
+                    "node_id": "657a80e9-f5af-45c3-b848-11d8f664d732",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4677,7 +4677,7 @@
                     "label": {
                         "en": "Data Assignment Label"
                     },
-                    "node_id": "d830c6c0-da2d-11ed-8e35-713b6788f6a4",
+                    "node_id": "a114037e-92fd-4436-a934-618951396344",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4814,7 +4814,7 @@
                     "label": {
                         "en": "Data Assigner"
                     },
-                    "node_id": "b6e3e93e-da2d-11ed-8e35-713b6788f6a4",
+                    "node_id": "c6609c2c-a549-40df-aaa7-558241b870e4",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
@@ -4887,7 +4887,7 @@
                     "label": {
                         "en": "Identifier Type"
                     },
-                    "node_id": "165b967c-da2a-11ed-8e35-713b6788f6a4",
+                    "node_id": "2a3828f4-4dca-43c5-96b5-30492a264c7c",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -5054,7 +5054,7 @@
                     "label": {
                         "en": "Identifier"
                     },
-                    "node_id": "6f33893a-da2a-11ed-8e35-713b6788f6a4",
+                    "node_id": "83dd1520-83d1-42d0-ae2e-ccfe9d54560b",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -5184,7 +5184,7 @@
                     "label": {
                         "en": "Object Used in Identifier Assignment"
                     },
-                    "node_id": "7876444e-da2d-11ed-8e35-713b6788f6a4",
+                    "node_id": "4bdcddb9-ae65-406b-ac53-c88e18032b1a",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
@@ -5554,9 +5554,7 @@
                 {
                     "card_id": "4952a8f4-bb15-11ea-85a6-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -7852,7 +7850,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "9df5cba2-4b1c-11ee-8a8d-11afefc4bff7",
+                    "node_id": "131de67f-64e8-4460-980e-5ce1ea479c38",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -7881,7 +7879,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "9df5cb9f-4b1c-11ee-8a8d-11afefc4bff7",
+                    "node_id": "525ca417-9b32-4541-9adb-3e619ca3f62f",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -7910,7 +7908,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "9df5cb9a-4b1c-11ee-8a8d-11afefc4bff7",
+                    "node_id": "81950ad8-1ca0-4ed6-ab5f-4b8ad2b55464",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -7932,7 +7930,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "9df5cbad-4b1c-11ee-8a8d-11afefc4bff7",
+                    "node_id": "1e0789a3-bfe3-4bde-8376-a8ab60e03b37",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -18233,6 +18231,105 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "rangenode_id": "ffd08d68-d8a8-11ed-8e35-713b6788f6a4"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "ffd08d68-d8a8-11ed-8e35-713b6788f6a4",
+                    "edgeid": "1e23cb1a-ce39-4a9b-afbb-035fad761d72",
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "2a3828f4-4dca-43c5-96b5-30492a264c7c"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "ffd08d68-d8a8-11ed-8e35-713b6788f6a4",
+                    "edgeid": "42667528-4c30-4dfa-aae1-2318afc74ff3",
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "83dd1520-83d1-42d0-ae2e-ccfe9d54560b"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4df6eeea-da2c-11ed-8e35-713b6788f6a4",
+                    "edgeid": "2e49f451-5850-4b96-aec8-17bcb56fedbf",
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P16_used_specific_object",
+                    "rangenode_id": "4bdcddb9-ae65-406b-ac53-c88e18032b1a"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4df6eeea-da2c-11ed-8e35-713b6788f6a4",
+                    "edgeid": "0d3ee7a6-4b58-4f30-aa26-384791a77dc5",
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "5d6ec944-9913-4aa6-b151-0e395caf019f"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "4f193102-b547-4831-8f50-5c8e141fc1e3",
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "525ca417-9b32-4541-9adb-3e619ca3f62f"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "425edcd2-5b7a-4e98-81ee-6a648152a19e",
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "1e0789a3-bfe3-4bde-8376-a8ab60e03b37"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "55bf82ae-393e-4da3-876d-bb386dfffd8d",
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "81950ad8-1ca0-4ed6-ab5f-4b8ad2b55464"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "8033fef2-2f08-4661-9efc-a9661d21919e",
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "131de67f-64e8-4460-980e-5ce1ea479c38"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "ffd08d68-d8a8-11ed-8e35-713b6788f6a4",
+                    "edgeid": "fee0ee7b-6a56-4e4b-9c61-f2a5e4f33d82",
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "657a80e9-f5af-45c3-b848-11d8f664d732"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4df6eeea-da2c-11ed-8e35-713b6788f6a4",
+                    "edgeid": "aff09615-20c4-4d3b-9e23-4e99459a9e2f",
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P14_carried_out_by",
+                    "rangenode_id": "c6609c2c-a549-40df-aaa7-558241b870e4"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4df6eeea-da2c-11ed-8e35-713b6788f6a4",
+                    "edgeid": "202ed640-d9a0-45d5-b5b2-e7037cc1b81e",
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "a114037e-92fd-4436-a934-618951396344"
                 }
             ],
             "functions_x_graphs": [
@@ -21990,7 +22087,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "birth_identifier_data_assignment_object_used",
+                    "alias": "birth_identifier_data_assignment_object_used_1",
                     "config": {
                         "graphs": [
                             {
@@ -22027,7 +22124,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "birth_identifier_data_assignment_object_used",
+                    "name": "birth_identifier_data_assignment_object_used_1",
                     "nodegroup_id": "4df6eeea-da2c-11ed-8e35-713b6788f6a4",
                     "nodeid": "7876444e-da2d-11ed-8e35-713b6788f6a4",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E70_Thing",
@@ -22126,7 +22223,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "birth_identifier_data_assignment_type",
+                    "alias": "birth_identifier_data_assignment_type_1",
                     "config": {
                         "rdmCollection": "a1b803ad-1ff7-4d5f-bb88-fcb7c48b906a"
                     },
@@ -22140,7 +22237,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "birth_identifier_data_assignment_type",
+                    "name": "birth_identifier_data_assignment_type_1",
                     "nodegroup_id": "4df6eeea-da2c-11ed-8e35-713b6788f6a4",
                     "nodeid": "7bc91414-da2d-11ed-8e35-713b6788f6a4",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -23752,7 +23849,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "death_identifier_data_assignment_statement_name_label",
+                    "alias": "death_identifier_data_assignment_statement_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -23764,7 +23861,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "death_identifier_data_assignment_statement_name_label",
+                    "name": "death_identifier_data_assignment_statement_name_label_1",
                     "nodegroup_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
                     "nodeid": "9df5cb9a-4b1c-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -23861,7 +23958,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "death_identifier_data_assignment_statement_name_content",
+                    "alias": "death_identifier_data_assignment_statement_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -23873,7 +23970,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "death_identifier_data_assignment_statement_name_content",
+                    "name": "death_identifier_data_assignment_statement_name_content_1",
                     "nodegroup_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
                     "nodeid": "9df5cb9f-4b1c-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -23928,7 +24025,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "death_identifier_data_assignment_statement_name_type",
+                    "alias": "death_identifier_data_assignment_statement_name_type_1",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -23942,7 +24039,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "death_identifier_data_assignment_statement_name_type",
+                    "name": "death_identifier_data_assignment_statement_name_type_1",
                     "nodegroup_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
                     "nodeid": "9df5cba2-4b1c-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -24173,7 +24270,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "death_identifier_data_assignment_statement_name_language",
+                    "alias": "death_identifier_data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -24187,7 +24284,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "death_identifier_data_assignment_statement_name_language",
+                    "name": "death_identifier_data_assignment_statement_name_language_1",
                     "nodegroup_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
                     "nodeid": "9df5cbad-4b1c-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -25648,7 +25745,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "birth_identifier_label",
+                    "alias": "birth_identifier_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -25660,7 +25757,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "birth_identifier_label",
+                    "name": "birth_identifier_label_1",
                     "nodegroup_id": "ffd08d68-d8a8-11ed-8e35-713b6788f6a4",
                     "nodeid": "ad575d54-da2a-11ed-8e35-713b6788f6a4",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -29004,7 +29101,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "birth_identifier_data_assignment_label",
+                    "alias": "birth_identifier_data_assignment_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -29016,7 +29113,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "birth_identifier_data_assignment_label",
+                    "name": "birth_identifier_data_assignment_label_1",
                     "nodegroup_id": "4df6eeea-da2c-11ed-8e35-713b6788f6a4",
                     "nodeid": "d830c6c0-da2d-11ed-8e35-713b6788f6a4",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -30292,6 +30389,283 @@
                     "nodeid": "ffd08d68-d8a8-11ed-8e35-713b6788f6a4",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E42_Identifier",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "birth_identifier_type_1",
+                    "config": {
+                        "rdmCollection": "1fc06e2f-d87f-458d-9421-1566e1121885"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "birth_identifier_type_1",
+                    "nodegroup_id": "ffd08d68-d8a8-11ed-8e35-713b6788f6a4",
+                    "nodeid": "2a3828f4-4dca-43c5-96b5-30492a264c7c",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "birth_identifier_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "birth_identifier_content_1",
+                    "nodegroup_id": "ffd08d68-d8a8-11ed-8e35-713b6788f6a4",
+                    "nodeid": "83dd1520-83d1-42d0-ae2e-ccfe9d54560b",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "birth_identifier_data_assignment_object_used",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                                "name": "Visual Work"
+                            },
+                            {
+                                "graphid": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                                "name": "Textual Work"
+                            },
+                            {
+                                "graphid": "0044f7da-b4b6-11ea-84f7-3af9d3b32b71",
+                                "name": "Digital Object"
+                            },
+                            {
+                                "graphid": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                                "name": "Physical Object"
+                            },
+                            {
+                                "graphid": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                                "name": "Set"
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "birth_identifier_data_assignment_object_used",
+                    "nodegroup_id": "4df6eeea-da2c-11ed-8e35-713b6788f6a4",
+                    "nodeid": "4bdcddb9-ae65-406b-ac53-c88e18032b1a",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E70_Thing",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P16_used_specific_object",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "birth_identifier_data_assignment_type",
+                    "config": {
+                        "rdmCollection": "a1b803ad-1ff7-4d5f-bb88-fcb7c48b906a"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "birth_identifier_data_assignment_type",
+                    "nodegroup_id": "4df6eeea-da2c-11ed-8e35-713b6788f6a4",
+                    "nodeid": "5d6ec944-9913-4aa6-b151-0e395caf019f",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "death_identifier_data_assignment_statement_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "death_identifier_data_assignment_statement_name_label",
+                    "nodegroup_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "81950ad8-1ca0-4ed6-ab5f-4b8ad2b55464",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "death_identifier_data_assignment_statement_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "death_identifier_data_assignment_statement_name_content",
+                    "nodegroup_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "525ca417-9b32-4541-9adb-3e619ca3f62f",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "death_identifier_data_assignment_statement_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "death_identifier_data_assignment_statement_name_type",
+                    "nodegroup_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "131de67f-64e8-4460-980e-5ce1ea479c38",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "death_identifier_data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "death_identifier_data_assignment_statement_name_language",
+                    "nodegroup_id": "9df5cb8f-4b1c-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "1e0789a3-bfe3-4bde-8376-a8ab60e03b37",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "birth_identifier_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "birth_identifier_label",
+                    "nodegroup_id": "ffd08d68-d8a8-11ed-8e35-713b6788f6a4",
+                    "nodeid": "657a80e9-f5af-45c3-b848-11d8f664d732",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "birth_identifier_data_assignment_actor_1",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                                "name": "Person"
+                            },
+                            {
+                                "graphid": "d6774bfc-b4b4-11ea-84f7-3af9d3b32b71",
+                                "name": "Group"
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "birth_identifier_data_assignment_actor_1",
+                    "nodegroup_id": "4df6eeea-da2c-11ed-8e35-713b6788f6a4",
+                    "nodeid": "c6609c2c-a549-40df-aaa7-558241b870e4",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E39_Actor",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P14_carried_out_by",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "birth_identifier_data_assignment_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "9ffb6fcc-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "birth_identifier_data_assignment_label",
+                    "nodegroup_id": "4df6eeea-da2c-11ed-8e35-713b6788f6a4",
+                    "nodeid": "a114037e-92fd-4436-a934-618951396344",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 }

--- a/graphs/resource_models/Physical Object.json
+++ b/graphs/resource_models/Physical Object.json
@@ -5196,7 +5196,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "56330cab-0635-11ee-8f04-cd21e680a247",
+                    "node_id": "1522ca75-5ea0-4454-ac08-4092383c8cbc",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -5225,7 +5225,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "56330ca7-0635-11ee-8f04-cd21e680a247",
+                    "node_id": "dd648b7f-201c-4f89-8200-04abf8f8f86a",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -5254,7 +5254,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "56330ca8-0635-11ee-8f04-cd21e680a247",
+                    "node_id": "8a1284a2-22f6-44ef-93a8-ea4d446267b4",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -5276,7 +5276,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "56330cd0-0635-11ee-8f04-cd21e680a247",
+                    "node_id": "1a9027eb-527d-4fe8-af09-3210ab46eac2",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -5319,7 +5319,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "4b8c4fb3-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "08eaf6fa-9c20-4767-ae73-898aea55fdb5",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -5348,7 +5348,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "4b8c4f87-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "e975a3b8-0017-41af-af49-dad83adc5036",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -5370,7 +5370,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "4b8c4f88-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "26ea669d-b540-42ba-9b18-c18b68491566",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -5399,7 +5399,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "4b8c4f89-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "bf37191e-f949-4a41-a769-fec4bfea4e50",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -7009,7 +7009,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "4b8c4fa4-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "e6481dca-ae30-4e96-ae52-b5ad20467496",
                     "sortorder": 4,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -7031,7 +7031,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "4b8c4fa1-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "646f16b4-455d-48c9-af5d-8ea31069eb36",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -7060,7 +7060,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "4b8c4fb2-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "1601ac42-9b27-440a-9e5e-d85b603b95e6",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -7082,7 +7082,7 @@
                     "label": {
                         "en": "Statement Type"
                     },
-                    "node_id": "4b8c4f99-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "cda4442f-cf9f-4531-bc59-073e185f015b",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -7104,7 +7104,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "4b8c4fa7-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "996401d9-486e-4a1f-bef6-a4a3faa652af",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -8785,7 +8785,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "4b8c4faf-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "5dac81d2-37f2-4c04-a538-2f800e8377ef",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -8807,7 +8807,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "4b8c4fac-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "b869235b-2cff-44b3-85a0-9c1aa4fa2c2a",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -8836,7 +8836,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "4b8c4fae-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "4744f18f-facd-418c-a19f-22707652cd97",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -8858,7 +8858,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "4b8c4fb1-3649-11ee-8a8d-11afefc4bff7",
+                    "node_id": "a5b3d69e-9b8c-48df-9c91-b0707ca14e52",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -11314,7 +11314,7 @@
                     "label": {
                         "en": "Earliest Start Date"
                     },
-                    "node_id": "ee5730ea-bacf-11ea-81b2-3af9d3b32b71",
+                    "node_id": "487ad671-e9f9-420f-832a-125c019b45d5",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000004"
@@ -11334,7 +11334,7 @@
                     "label": {
                         "en": "Latest End Date"
                     },
-                    "node_id": "ee572898-bacf-11ea-81b2-3af9d3b32b71",
+                    "node_id": "13d063d9-bed2-447b-bbfa-085a01fae55c",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000004"
@@ -11354,7 +11354,7 @@
                     "label": {
                         "en": "Earliest End Date"
                     },
-                    "node_id": "ee573b44-bacf-11ea-81b2-3af9d3b32b71",
+                    "node_id": "07579620-32f5-43ca-89d0-5a261b5d1cc0",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000004"
@@ -11383,7 +11383,7 @@
                     "label": {
                         "en": "Production Event Time Span Label"
                     },
-                    "node_id": "ee573612-bacf-11ea-81b2-3af9d3b32b71",
+                    "node_id": "800fa4e4-5a3d-4f04-9e1d-332e18dc927a",
                     "sortorder": 9,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -11405,7 +11405,7 @@
                     "label": {
                         "en": "Production Event TimeSpan Type"
                     },
-                    "node_id": "ee572d34-bacf-11ea-81b2-3af9d3b32b71",
+                    "node_id": "3969dc7b-3d0e-4ea8-be1a-2212e60ba5a9",
                     "sortorder": 11,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -11425,7 +11425,7 @@
                     "label": {
                         "en": "Latest Start Date"
                     },
-                    "node_id": "ee573400-bacf-11ea-81b2-3af9d3b32b71",
+                    "node_id": "60bdae8a-b625-45b5-b9e6-9bb272317c60",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000004"
@@ -12593,9 +12593,7 @@
                 {
                     "card_id": "6a9e73da-c2b8-11ea-af13-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -16922,7 +16920,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "56330cce-0635-11ee-8f04-cd21e680a247",
+                    "node_id": "e9728f8b-8846-44f9-9120-2a07efa284d7",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -16944,7 +16942,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "56330cca-0635-11ee-8f04-cd21e680a247",
+                    "node_id": "e189f2fb-c4db-4b88-9c9c-78a04fdd4e1b",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -16966,7 +16964,7 @@
                     "label": {
                         "en": "Statement Type"
                     },
-                    "node_id": "56330ccb-0635-11ee-8f04-cd21e680a247",
+                    "node_id": "27e22c2a-f742-4299-87b6-4c20bee7dd86",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -16988,7 +16986,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "56330ccf-0635-11ee-8f04-cd21e680a247",
+                    "node_id": "1be9e255-17aa-449f-add4-7fed9b25a826",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -17017,7 +17015,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "56330caa-0635-11ee-8f04-cd21e680a247",
+                    "node_id": "1b55c79c-9732-4445-9ec9-36385c5f57da",
                     "sortorder": 4,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -25964,6 +25962,276 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span",
                     "rangenode_id": "fcbe2882-045e-11ee-8f04-cd21e680a247"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4f86-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "50fd6204-56cf-44d1-b0b7-d38eda724944",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "e975a3b8-0017-41af-af49-dad83adc5036"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4f86-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "c5b0e7d7-78e5-41f5-a9ed-1ca4c3ff49c1",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "26ea669d-b540-42ba-9b18-c18b68491566"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4f86-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "1cf67e7b-6ae7-4201-87ff-5e2ae2524e55",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "bf37191e-f949-4a41-a769-fec4bfea4e50"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4f86-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "6fd25af3-c016-4cf8-bc40-dfcd784c6059",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "08eaf6fa-9c20-4767-ae73-898aea55fdb5"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4f97-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "15871fff-cfb8-4b62-8d70-34ec50d932b8",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "646f16b4-455d-48c9-af5d-8ea31069eb36"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4f97-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "06bf8043-54e6-474c-93f2-f256db34e790",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "e6481dca-ae30-4e96-ae52-b5ad20467496"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4f97-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "d84982c5-3a77-4360-a4d8-1609177b5d23",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "cda4442f-cf9f-4531-bc59-073e185f015b"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4f99-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "ef979f56-a8ad-43c5-8d41-4932f4d9e464",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "996401d9-486e-4a1f-bef6-a4a3faa652af"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "cda4442f-cf9f-4531-bc59-073e185f015b",
+                    "edgeid": "fca88574-1058-4370-ad8e-ff0ed3be0b21",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "4b8c4fa7-3649-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4fa9-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "a2c08a47-41a4-49b8-8360-d9e570a204d0",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "b869235b-2cff-44b3-85a0-9c1aa4fa2c2a"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4fa9-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "8fe055df-89f9-476f-b8f8-e03ab0e2d60d",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "4744f18f-facd-418c-a19f-22707652cd97"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4fa9-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "31e1a34d-37a0-4f57-93b2-b9d3060c2ed3",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "5dac81d2-37f2-4c04-a538-2f800e8377ef"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4fa9-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "905ba0dc-f8de-4c08-be3e-8de5dd99019a",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "a5b3d69e-9b8c-48df-9c91-b0707ca14e52"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "4b8c4f97-3649-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "32359715-d761-418d-b0ea-a678594554f4",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "1601ac42-9b27-440a-9e5e-d85b603b95e6"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
+                    "edgeid": "ffb8e772-be82-4319-9fa6-51bc4a18cd8e",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "e9728f8b-8846-44f9-9120-2a07efa284d7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "56330cbe-0635-11ee-8f04-cd21e680a247",
+                    "edgeid": "1191797f-4a9c-47f3-8631-b61dffb5e373",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "1a9027eb-527d-4fe8-af09-3210ab46eac2"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "56330cbe-0635-11ee-8f04-cd21e680a247",
+                    "edgeid": "a8526c51-4244-4f64-981d-3262a22e99f5",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "dd648b7f-201c-4f89-8200-04abf8f8f86a"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "56330cbe-0635-11ee-8f04-cd21e680a247",
+                    "edgeid": "0660adc7-7f69-4bf7-b4ed-9920d06b1bc7",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "8a1284a2-22f6-44ef-93a8-ea4d446267b4"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "56330cbe-0635-11ee-8f04-cd21e680a247",
+                    "edgeid": "79066b8a-b007-4e4f-95dd-464ddc82813c",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "1522ca75-5ea0-4454-ac08-4092383c8cbc"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
+                    "edgeid": "ba8ea981-e8de-4da4-b165-d7cfd95e693a",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "27e22c2a-f742-4299-87b6-4c20bee7dd86"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "56330ccb-0635-11ee-8f04-cd21e680a247",
+                    "edgeid": "abe791ea-b14d-4416-90e1-3708e7652f2c",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "e189f2fb-c4db-4b88-9c9c-78a04fdd4e1b"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "27e22c2a-f742-4299-87b6-4c20bee7dd86",
+                    "edgeid": "0cfe8e0d-4014-4b13-b983-f70bb2e5452f",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "56330cca-0635-11ee-8f04-cd21e680a247"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
+                    "edgeid": "ca8ce23c-a31e-497b-b37b-a58bd74fe71c",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "1b55c79c-9732-4445-9ec9-36385c5f57da"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
+                    "edgeid": "06521649-e6ab-4b48-bc3b-3c160cabc2ec",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "1be9e255-17aa-449f-add4-7fed9b25a826"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "edgeid": "0b460e72-548b-4495-9c0f-86188a0555b7",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "3969dc7b-3d0e-4ea8-be1a-2212e60ba5a9"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "edgeid": "b70cf9e9-3c7b-470b-9568-8619cbde83a5",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P81a_end_of_the_begin",
+                    "rangenode_id": "60bdae8a-b625-45b5-b9e6-9bb272317c60"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "edgeid": "80de6643-a857-41ea-a0d2-0b9e40d34742",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P81b_begin_of_the_end",
+                    "rangenode_id": "07579620-32f5-43ca-89d0-5a261b5d1cc0"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "edgeid": "aaa088cf-364f-45f5-8efc-4d895ba2e1d7",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P82b_end_of_the_end",
+                    "rangenode_id": "13d063d9-bed2-447b-bbfa-085a01fae55c"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "edgeid": "8ec04d0a-67b6-4b83-86d5-ccdb3d455f0a",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "800fa4e4-5a3d-4f04-9e1d-332e18dc927a"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "edgeid": "cf1467c4-66a8-4983-958c-91f674694de6",
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
+                    "rangenode_id": "487ad671-e9f9-420f-832a-125c019b45d5"
                 }
             ],
             "functions_x_graphs": [
@@ -31008,7 +31276,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_name_type",
+                    "alias": "data_assignment_name_type_1",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -31022,7 +31290,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_name_type",
+                    "name": "data_assignment_name_type_1",
                     "nodegroup_id": "4b8c4f86-3649-11ee-8a8d-11afefc4bff7",
                     "nodeid": "4b8c4f88-3649-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -31861,7 +32129,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_name_label",
+                    "alias": "data_assignment_statement_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -31873,7 +32141,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_name_label",
+                    "name": "data_assignment_statement_name_label_1",
                     "nodegroup_id": "4b8c4fa9-3649-11ee-8a8d-11afefc4bff7",
                     "nodeid": "4b8c4fae-3649-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -31949,7 +32217,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_content",
+                    "alias": "data_assignment_statement_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -31961,7 +32229,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_content",
+                    "name": "data_assignment_statement_content_1",
                     "nodegroup_id": "4b8c4f97-3649-11ee-8a8d-11afefc4bff7",
                     "nodeid": "4b8c4fb2-3649-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -31970,7 +32238,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_name_language",
+                    "alias": "data_assignment_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -31984,7 +32252,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_name_language",
+                    "name": "data_assignment_name_language_1",
                     "nodegroup_id": "4b8c4f86-3649-11ee-8a8d-11afefc4bff7",
                     "nodeid": "4b8c4fb3-3649-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -33700,7 +33968,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_label",
+                    "alias": "identifier_data_assignment_statement_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -33712,7 +33980,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_label",
+                    "name": "identifier_data_assignment_statement_label_1",
                     "nodegroup_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
                     "nodeid": "56330caa-0635-11ee-8f04-cd21e680a247",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -33721,7 +33989,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_language",
+                    "alias": "identifier_data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -33735,7 +34003,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_language",
+                    "name": "identifier_data_assignment_statement_name_language_1",
                     "nodegroup_id": "56330cbe-0635-11ee-8f04-cd21e680a247",
                     "nodeid": "56330cab-0635-11ee-8f04-cd21e680a247",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -34466,7 +34734,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_type",
+                    "alias": "identifier_data_assignment_statement_type_1",
                     "config": {
                         "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
                     },
@@ -34480,7 +34748,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_type",
+                    "name": "identifier_data_assignment_statement_type_1",
                     "nodegroup_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
                     "nodeid": "56330ccb-0635-11ee-8f04-cd21e680a247",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -34552,7 +34820,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_language",
+                    "alias": "identifier_data_assignment_statement_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -34566,7 +34834,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_language",
+                    "name": "identifier_data_assignment_statement_language_1",
                     "nodegroup_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
                     "nodeid": "56330ccf-0635-11ee-8f04-cd21e680a247",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -34575,7 +34843,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_type",
+                    "alias": "identifier_data_assignment_statement_name_type_1",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -34589,7 +34857,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_type",
+                    "name": "identifier_data_assignment_statement_name_type_1",
                     "nodegroup_id": "56330cbe-0635-11ee-8f04-cd21e680a247",
                     "nodeid": "56330cd0-0635-11ee-8f04-cd21e680a247",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -41149,7 +41417,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "production_timespan_end_of_the_end",
+                    "alias": "production_timespan_end_of_the_end_1",
                     "config": {
                         "dateFormat": "YYYY-MM-DD"
                     },
@@ -41163,7 +41431,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "production_timespan_end_of_the_end",
+                    "name": "production_timespan_end_of_the_end_1",
                     "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
                     "nodeid": "ee572898-bacf-11ea-81b2-3af9d3b32b71",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -41327,7 +41595,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "production_timespan_type",
+                    "alias": "production_timespan_type_1",
                     "config": {
                         "rdmCollection": "1dc58961-3e12-447c-9384-6b55765283a4"
                     },
@@ -41341,7 +41609,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "production_timespan_type",
+                    "name": "production_timespan_type_1",
                     "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
                     "nodeid": "ee572d34-bacf-11ea-81b2-3af9d3b32b71",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -41480,7 +41748,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "production_timespan_begin_of_the_begin",
+                    "alias": "production_timespan_begin_of_the_begin_1",
                     "config": {
                         "dateFormat": "YYYY-MM-DD"
                     },
@@ -41494,7 +41762,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "production_timespan_begin_of_the_begin",
+                    "name": "production_timespan_begin_of_the_begin_1",
                     "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
                     "nodeid": "ee5730ea-bacf-11ea-81b2-3af9d3b32b71",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -41593,7 +41861,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "production_timespan_end_of_the_begin",
+                    "alias": "production_timespan_end_of_the_begin_1",
                     "config": {
                         "dateFormat": "YYYY-MM-DD"
                     },
@@ -41607,7 +41875,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "production_timespan_end_of_the_begin",
+                    "name": "production_timespan_end_of_the_begin_1",
                     "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
                     "nodeid": "ee573400-bacf-11ea-81b2-3af9d3b32b71",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -41712,7 +41980,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "production_timespan_label",
+                    "alias": "production_timespan_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": "# Specific:\n\n\n# General:\nEvery node should have a _label that provides a human-readable summary label for the node. This is intended not for end users, but for developers looking at the data. See:  https://linked.art/model/base/#core-properties\n\n# Arches Note:\n\n\n* BranchId: la-label\n* FieldId: \n",
@@ -41724,7 +41992,7 @@
                     "isrequired": false,
                     "issearchable": false,
                     "istopnode": false,
-                    "name": "production_timespan_label",
+                    "name": "production_timespan_label_1",
                     "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
                     "nodeid": "ee573612-bacf-11ea-81b2-3af9d3b32b71",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -41930,7 +42198,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "production_timespan_begin_of_the_end",
+                    "alias": "production_timespan_begin_of_the_end_1",
                     "config": {
                         "dateFormat": "YYYY-MM-DD"
                     },
@@ -41944,7 +42212,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "production_timespan_begin_of_the_end",
+                    "name": "production_timespan_begin_of_the_end_1",
                     "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
                     "nodeid": "ee573b44-bacf-11ea-81b2-3af9d3b32b71",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -43139,6 +43407,628 @@
                     "nodeid": "fcbe28ad-045e-11ee-8f04-cd21e680a247",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_label_1",
+                    "nodegroup_id": "4b8c4f86-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "e975a3b8-0017-41af-af49-dad83adc5036",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_type",
+                    "nodegroup_id": "4b8c4f86-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "26ea669d-b540-42ba-9b18-c18b68491566",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_content_1",
+                    "nodegroup_id": "4b8c4f86-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "bf37191e-f949-4a41-a769-fec4bfea4e50",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_type_1",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_type_1",
+                    "nodegroup_id": "4b8c4f97-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "cda4442f-cf9f-4531-bc59-073e185f015b",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_language_1",
+                    "nodegroup_id": "4b8c4f97-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "646f16b4-455d-48c9-af5d-8ea31069eb36",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_label_1",
+                    "nodegroup_id": "4b8c4f97-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "e6481dca-ae30-4e96-ae52-b5ad20467496",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_type_metatype_1",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_type_metatype_1",
+                    "nodegroup_id": "4b8c4f97-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "996401d9-486e-4a1f-bef6-a4a3faa652af",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_language_1",
+                    "nodegroup_id": "4b8c4fa9-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "b869235b-2cff-44b3-85a0-9c1aa4fa2c2a",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_label",
+                    "nodegroup_id": "4b8c4fa9-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "4744f18f-facd-418c-a19f-22707652cd97",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_content_1",
+                    "nodegroup_id": "4b8c4fa9-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "5dac81d2-37f2-4c04-a538-2f800e8377ef",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_type_1",
+                    "nodegroup_id": "4b8c4fa9-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "a5b3d69e-9b8c-48df-9c91-b0707ca14e52",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_content",
+                    "nodegroup_id": "4b8c4f97-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "1601ac42-9b27-440a-9e5e-d85b603b95e6",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_language",
+                    "nodegroup_id": "4b8c4f86-3649-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "08eaf6fa-9c20-4767-ae73-898aea55fdb5",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_content_1",
+                    "nodegroup_id": "56330cbe-0635-11ee-8f04-cd21e680a247",
+                    "nodeid": "dd648b7f-201c-4f89-8200-04abf8f8f86a",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_label_1",
+                    "nodegroup_id": "56330cbe-0635-11ee-8f04-cd21e680a247",
+                    "nodeid": "8a1284a2-22f6-44ef-93a8-ea4d446267b4",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_label",
+                    "nodegroup_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
+                    "nodeid": "1b55c79c-9732-4445-9ec9-36385c5f57da",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_language",
+                    "nodegroup_id": "56330cbe-0635-11ee-8f04-cd21e680a247",
+                    "nodeid": "1522ca75-5ea0-4454-ac08-4092383c8cbc",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_type_metatype_1",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_type_metatype_1",
+                    "nodegroup_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
+                    "nodeid": "e189f2fb-c4db-4b88-9c9c-78a04fdd4e1b",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_type",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_type",
+                    "nodegroup_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
+                    "nodeid": "27e22c2a-f742-4299-87b6-4c20bee7dd86",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_content_1",
+                    "nodegroup_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
+                    "nodeid": "e9728f8b-8846-44f9-9120-2a07efa284d7",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_language",
+                    "nodegroup_id": "56330cc2-0635-11ee-8f04-cd21e680a247",
+                    "nodeid": "1be9e255-17aa-449f-add4-7fed9b25a826",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_type",
+                    "nodegroup_id": "56330cbe-0635-11ee-8f04-cd21e680a247",
+                    "nodeid": "1a9027eb-527d-4fe8-af09-3210ab46eac2",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "production_timespan_end_of_the_end",
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD"
+                    },
+                    "datatype": "date",
+                    "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "production_timespan_end_of_the_end",
+                    "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "nodeid": "13d063d9-bed2-447b-bbfa-085a01fae55c",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P82b_end_of_the_end",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "production_timespan_type",
+                    "config": {
+                        "rdmCollection": "1dc58961-3e12-447c-9384-6b55765283a4"
+                    },
+                    "datatype": "concept-list",
+                    "description": "# Specific:\n\n\n# General:\nIn order to make data both consistent and able to be customized to specific scenarios, nodes can be classified with terms from controlled vocabularies. This field gives a way to be more specific about the sort of entity, while maintaining the core information using the ontology class. See: https://linked.art/model/base/#types-and-classifications\n\n# Arches Note:\n\n\n* BranchId: la-classification\n* FieldId: \n",
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "production_timespan_type",
+                    "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "nodeid": "3969dc7b-3d0e-4ea8-be1a-2212e60ba5a9",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "production_timespan_begin_of_the_begin",
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD"
+                    },
+                    "datatype": "date",
+                    "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "production_timespan_begin_of_the_begin",
+                    "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "nodeid": "487ad671-e9f9-420f-832a-125c019b45d5",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "production_timespan_end_of_the_begin",
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD"
+                    },
+                    "datatype": "date",
+                    "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "production_timespan_end_of_the_begin",
+                    "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "nodeid": "60bdae8a-b625-45b5-b9e6-9bb272317c60",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P81a_end_of_the_begin",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "production_timespan_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": "# Specific:\n\n\n# General:\nEvery node should have a _label that provides a human-readable summary label for the node. This is intended not for end users, but for developers looking at the data. See:  https://linked.art/model/base/#core-properties\n\n# Arches Note:\n\n\n* BranchId: la-label\n* FieldId: \n",
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": false,
+                    "istopnode": false,
+                    "name": "production_timespan_label",
+                    "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "nodeid": "800fa4e4-5a3d-4f04-9e1d-332e18dc927a",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "production_timespan_begin_of_the_end",
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD"
+                    },
+                    "datatype": "date",
+                    "description": "# Specific:\n\n\n# General:\n\n\n# Arches Note:\n\n\n* BranchId: \n* FieldId: \n",
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "1810d182-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "production_timespan_begin_of_the_end",
+                    "nodegroup_id": "ee572550-bacf-11ea-81b2-3af9d3b32b71",
+                    "nodeid": "07579620-32f5-43ca-89d0-5a261b5d1cc0",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P81b_begin_of_the_end",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 }

--- a/graphs/resource_models/Place.json
+++ b/graphs/resource_models/Place.json
@@ -4255,7 +4255,7 @@
                     "label": {
                         "en": "Name Part Label"
                     },
-                    "node_id": "5f00c6e5-0650-11ee-8f04-cd21e680a247",
+                    "node_id": "0e6a5ce4-26d4-4f11-99f6-7e8acebf5304",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4277,7 +4277,7 @@
                     "label": {
                         "en": "Name Part Language"
                     },
-                    "node_id": "5f00c6e3-0650-11ee-8f04-cd21e680a247",
+                    "node_id": "b498ff67-0871-40e5-9028-901a2f291638",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -4299,7 +4299,7 @@
                     "label": {
                         "en": "Name Part Type"
                     },
-                    "node_id": "5f00c6e6-0650-11ee-8f04-cd21e680a247",
+                    "node_id": "c9f64b2d-d4c7-4d80-9357-b1518b21ff5f",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -4328,7 +4328,7 @@
                     "label": {
                         "en": "Name Part"
                     },
-                    "node_id": "5f00c6e8-0650-11ee-8f04-cd21e680a247",
+                    "node_id": "c17137f2-98ce-4933-95d2-c838ef7d48c4",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -5763,6 +5763,42 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "rangenode_id": "e88f553e-da16-11ed-8e35-713b6788f6a4"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5f00c6eb-0650-11ee-8f04-cd21e680a247",
+                    "edgeid": "fcdd653a-679c-48bc-a469-0b64aa42fe85",
+                    "graph_id": "f6e89030-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "c17137f2-98ce-4933-95d2-c838ef7d48c4"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5f00c6eb-0650-11ee-8f04-cd21e680a247",
+                    "edgeid": "7109b185-dc91-46dd-b452-fb95be6b6005",
+                    "graph_id": "f6e89030-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "0e6a5ce4-26d4-4f11-99f6-7e8acebf5304"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5f00c6eb-0650-11ee-8f04-cd21e680a247",
+                    "edgeid": "5d0823ff-e329-4286-90bf-77440ddcb5ff",
+                    "graph_id": "f6e89030-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "b498ff67-0871-40e5-9028-901a2f291638"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5f00c6eb-0650-11ee-8f04-cd21e680a247",
+                    "edgeid": "d1264407-99d1-487b-8eb2-ea25ef4dbf87",
+                    "graph_id": "f6e89030-b4b4-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "c9f64b2d-d4c7-4d80-9357-b1518b21ff5f"
                 }
             ],
             "functions_x_graphs": [
@@ -7627,7 +7663,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "name_part_label",
+                    "alias": "name_part_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -7639,7 +7675,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "name_part_label",
+                    "name": "name_part_label_1",
                     "nodegroup_id": "5f00c6eb-0650-11ee-8f04-cd21e680a247",
                     "nodeid": "5f00c6e5-0650-11ee-8f04-cd21e680a247",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -9523,6 +9559,94 @@
                     "nodeid": "f6e88e3c-b4b4-11ea-84f7-3af9d3b32b71",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E53_Place",
                     "parentproperty": "",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "name_part_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "f6e89030-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "name_part_language_1",
+                    "nodegroup_id": "5f00c6eb-0650-11ee-8f04-cd21e680a247",
+                    "nodeid": "b498ff67-0871-40e5-9028-901a2f291638",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "name_part_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "f6e89030-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "name_part_label",
+                    "nodegroup_id": "5f00c6eb-0650-11ee-8f04-cd21e680a247",
+                    "nodeid": "0e6a5ce4-26d4-4f11-99f6-7e8acebf5304",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "name_part_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "f6e89030-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "name_part_type_1",
+                    "nodegroup_id": "5f00c6eb-0650-11ee-8f04-cd21e680a247",
+                    "nodeid": "c9f64b2d-d4c7-4d80-9357-b1518b21ff5f",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "name_part_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "f6e89030-b4b4-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "name_part_content_1",
+                    "nodegroup_id": "5f00c6eb-0650-11ee-8f04-cd21e680a247",
+                    "nodeid": "c17137f2-98ce-4933-95d2-c838ef7d48c4",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 }

--- a/graphs/resource_models/Provenance Activity.json
+++ b/graphs/resource_models/Provenance Activity.json
@@ -61,35 +61,6 @@
                 },
                 {
                     "active": true,
-                    "cardid": "078be4c4-4be9-11ee-8a8d-11afefc4bff7",
-                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
-                    "config": null,
-                    "constraints": [],
-                    "cssclass": null,
-                    "description": {
-                        "en": null
-                    },
-                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
-                    "helpenabled": false,
-                    "helptext": {
-                        "en": null
-                    },
-                    "helptitle": {
-                        "en": null
-                    },
-                    "instructions": {
-                        "en": null
-                    },
-                    "is_editable": true,
-                    "name": {
-                        "en": "New Node"
-                    },
-                    "nodegroup_id": "078be4c2-4be9-11ee-8a8d-11afefc4bff7",
-                    "sortorder": 26,
-                    "visible": true
-                },
-                {
-                    "active": true,
                     "cardid": "09517e8e-41dc-11ee-8a8d-11afefc4bff7",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -2410,35 +2381,6 @@
                     },
                     "nodegroup_id": "6867bd48-47c9-11ee-8a8d-11afefc4bff7",
                     "sortorder": 1,
-                    "visible": true
-                },
-                {
-                    "active": true,
-                    "cardid": "6a0bb6c0-4be8-11ee-8a8d-11afefc4bff7",
-                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
-                    "config": null,
-                    "constraints": [],
-                    "cssclass": null,
-                    "description": {
-                        "en": null
-                    },
-                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
-                    "helpenabled": false,
-                    "helptext": {
-                        "en": null
-                    },
-                    "helptitle": {
-                        "en": null
-                    },
-                    "instructions": {
-                        "en": null
-                    },
-                    "is_editable": true,
-                    "name": {
-                        "en": "New Node"
-                    },
-                    "nodegroup_id": "6a0bb6be-4be8-11ee-8a8d-11afefc4bff7",
-                    "sortorder": 25,
                     "visible": true
                 },
                 {
@@ -6867,7 +6809,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "30766bcd-472b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "a32dc20b-4731-4069-bee2-e80124a0911e",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -6889,7 +6831,7 @@
                     "label": {
                         "en": "Statement Type"
                     },
-                    "node_id": "30766bf2-472b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "97e9d893-33b4-48b4-9733-8022e0166cda",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6911,7 +6853,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "30766bd1-472b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "c4b49865-61ab-46c3-a492-f3d3432aed1b",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6933,7 +6875,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "30766bf3-472b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "e4d5812e-6284-43f3-a1f0-7d45d9a9d010",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -6962,7 +6904,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "30766bd0-472b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "ecd63fa9-7d83-49d6-90ca-4067c70ff8bf",
                     "sortorder": 4,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -9958,7 +9900,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "30766be5-472b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "702e963d-ad95-49ae-8317-4bce37a84a2e",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -9987,7 +9929,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "30766bed-472b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "b687bf04-7b38-409c-9867-5706f871044c",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -10009,7 +9951,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "30766bec-472b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "39893056-3aba-4e38-b279-93dff7d30d39",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -10031,7 +9973,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "30766bf5-472b-11ee-8a8d-11afefc4bff7",
+                    "node_id": "26f34b22-d48d-43c9-b0aa-d2f6dd513ea4",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -12501,9 +12443,7 @@
                 {
                     "card_id": "53d8adc3-47c9-11ee-8a8d-11afefc4bff7",
                     "config": {
-                        "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -13561,7 +13501,7 @@
                     "label": {
                         "en": "move_identifier_data_assignment_statement_content"
                     },
-                    "node_id": "77f3fb4d-47c9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "35262508-10c0-45ff-9a8c-7273d651fa2f",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -13590,7 +13530,7 @@
                     "label": {
                         "en": "move_identifier_data_assignment_statement_label"
                     },
-                    "node_id": "77f3fb50-47c9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "d810d16b-d117-4a9b-bb1e-7af75e471892",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -13612,7 +13552,7 @@
                     "label": {
                         "en": "move_identifier_data_assignment_statement_language"
                     },
-                    "node_id": "77f3fb51-47c9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "06ef2121-20d3-4c77-bcd4-49b1dc0ff090",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -13641,7 +13581,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "77f3fb65-47c9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "ee402c53-3236-4959-bf80-ffb07cc574fc",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -13663,7 +13603,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "77f3fb6c-47c9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "d57e4c85-bd11-48ed-af5d-8c71228af7e4",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -13692,7 +13632,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "77f3fb6d-47c9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "5ca3ee0c-5431-4fd0-930a-308b9f25939b",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -13714,7 +13654,7 @@
                     "label": {
                         "en": "move_identifier_data_assignment_statement_type"
                     },
-                    "node_id": "77f3fb72-47c9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "01955393-05b9-468a-a743-548d47089940",
                     "sortorder": 9,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -13736,7 +13676,7 @@
                     "label": {
                         "en": "move_identifier_data_assignment_statement_type_metatype"
                     },
-                    "node_id": "77f3fb73-47c9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "d1161110-eb1d-43c0-b63e-b801761f4619",
                     "sortorder": 10,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -13758,7 +13698,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "77f3fb75-47c9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "3e93c99f-23a9-4702-8237-c35d84124af9",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -13912,9 +13852,7 @@
                 {
                     "card_id": "5cc34790-4e2f-11ee-8a8d-11afefc4bff7",
                     "config": {
-                        "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -21563,7 +21501,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "5661f29e-4bd3-11ee-8a8d-11afefc4bff7",
+                    "node_id": "e7cafe06-e67b-4fa2-b9e5-2a9852aab17b",
                     "sortorder": 4,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -21585,7 +21523,7 @@
                     "label": {
                         "en": "rights_acquisition_data_assignment_statement_type"
                     },
-                    "node_id": "5661f2c0-4bd3-11ee-8a8d-11afefc4bff7",
+                    "node_id": "84d45ce0-18f6-488b-8fc9-405aa46a923f",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -21607,7 +21545,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "5661f29f-4bd3-11ee-8a8d-11afefc4bff7",
+                    "node_id": "a3de4993-119f-4ba7-b6cf-d10914bb4368",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -21636,7 +21574,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "5661f29b-4bd3-11ee-8a8d-11afefc4bff7",
+                    "node_id": "980009e5-d3ff-4963-9146-25254da37ab6",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -21658,7 +21596,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "5661f2c1-4bd3-11ee-8a8d-11afefc4bff7",
+                    "node_id": "2247da2b-6922-438a-81b6-d7706e6ef3aa",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -21753,9 +21691,7 @@
                 {
                     "card_id": "aed56089-47e9-11ee-8a8d-11afefc4bff7",
                     "config": {
-                        "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -28573,7 +28509,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "5661f2b3-4bd3-11ee-8a8d-11afefc4bff7",
+                    "node_id": "96e62b09-5f86-4617-9b18-ab4adf436c85",
                     "sortorder": null,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -28595,7 +28531,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "5661f2ba-4bd3-11ee-8a8d-11afefc4bff7",
+                    "node_id": "da3cb647-9462-4f01-8a94-4078ec1bfebc",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -28624,7 +28560,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "5661f2bb-4bd3-11ee-8a8d-11afefc4bff7",
+                    "node_id": "3c98db5d-5c59-4805-8a6c-9038d5296241",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -28762,7 +28698,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "5661f2c3-4bd3-11ee-8a8d-11afefc4bff7",
+                    "node_id": "6d28ffe0-3b3e-4671-a82d-ff4ca6abbebf",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -43379,6 +43315,276 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P9_consists_of",
                     "rangenode_id": "fe72e57c-bbcf-11ea-ad92-3af9d3b32b71"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "30766bf4-472b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "df767fd0-7801-40ff-b36c-a71456928718",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "26f34b22-d48d-43c9-b0aa-d2f6dd513ea4"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "30766bf4-472b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "7a095d3e-c798-49b6-9861-519a9eada286",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "702e963d-ad95-49ae-8317-4bce37a84a2e"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "30766bf4-472b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "b2538a07-184e-4c63-9141-a2f45b681184",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "b687bf04-7b38-409c-9867-5706f871044c"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "30766bf4-472b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "31beb07b-a1c9-4218-9199-909d870bc482",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "39893056-3aba-4e38-b279-93dff7d30d39"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "30766bf1-472b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "c671602a-903e-41df-8dda-46e9a95a5259",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "a32dc20b-4731-4069-bee2-e80124a0911e"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "30766bf1-472b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "a8566aa7-a4ba-454b-9ba8-a4bc955cd2a7",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "ecd63fa9-7d83-49d6-90ca-4067c70ff8bf"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "30766bf1-472b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "ed391c64-3bba-46f5-91a7-f22061d3d6b9",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "97e9d893-33b4-48b4-9733-8022e0166cda"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "30766bf2-472b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "0ccb4f28-6a28-496d-8b49-4991a8db17f5",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "e4d5812e-6284-43f3-a1f0-7d45d9a9d010"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "97e9d893-33b4-48b4-9733-8022e0166cda",
+                    "edgeid": "63d237ac-ca3a-4a88-a706-41e121cce84c",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "30766bf3-472b-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "30766bf1-472b-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "f7e134f9-c0fe-492d-9de0-4f7f5f0197b4",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "c4b49865-61ab-46c3-a492-f3d3432aed1b"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5661f2c2-4bd3-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "b50322a2-5891-478d-b8da-61e3d6664b11",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "6d28ffe0-3b3e-4671-a82d-ff4ca6abbebf"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5661f2c2-4bd3-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "1b6a5fcc-8301-40d3-95d1-d9b433bde6aa",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "96e62b09-5f86-4617-9b18-ab4adf436c85"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5661f2c2-4bd3-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "26f9136d-e1c5-41fd-9df2-d284c9345869",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "3c98db5d-5c59-4805-8a6c-9038d5296241"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5661f2c2-4bd3-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "ed970dc2-0093-4d64-a069-ca5acf26bbde",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "da3cb647-9462-4f01-8a94-4078ec1bfebc"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5661f2bf-4bd3-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "5e270d9f-e925-4258-bedf-306fa8e3fd04",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "980009e5-d3ff-4963-9146-25254da37ab6"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5661f2bf-4bd3-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "3fab86bb-d9ed-4c39-974f-56b34a7be6e7",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "e7cafe06-e67b-4fa2-b9e5-2a9852aab17b"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5661f2bf-4bd3-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "204ac51e-cbd3-4337-b380-24184623ef8c",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "84d45ce0-18f6-488b-8fc9-405aa46a923f"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5661f2c0-4bd3-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "0849942e-3e3c-4074-866b-f280f7afa340",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "2247da2b-6922-438a-81b6-d7706e6ef3aa"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "84d45ce0-18f6-488b-8fc9-405aa46a923f",
+                    "edgeid": "e731fd9b-e0b0-46ec-b277-3a0dcac7ae55",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "5661f2c1-4bd3-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "5661f2bf-4bd3-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "e436a1f2-c034-4d3f-808b-d4d9738e5d75",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "a3de4993-119f-4ba7-b6cf-d10914bb4368"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "77f3fb74-47c9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "7efc9b06-391b-4780-bf6b-449c9745b0b8",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "3e93c99f-23a9-4702-8237-c35d84124af9"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "77f3fb74-47c9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "5fd072fc-acfd-4a2e-9574-4abd53c105a1",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "ee402c53-3236-4959-bf80-ffb07cc574fc"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "77f3fb74-47c9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "9ad1444e-620f-44bd-b720-62835424fcf7",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "5ca3ee0c-5431-4fd0-930a-308b9f25939b"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "77f3fb74-47c9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "e1e46361-b0ab-4794-be25-f6197223ddfe",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "d57e4c85-bd11-48ed-af5d-8c71228af7e4"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "837ce198-a37d-4330-afeb-4030e495e430",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "35262508-10c0-45ff-9a8c-7273d651fa2f"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "f96d94ab-371f-44e5-82c3-25ff76954a68",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "d810d16b-d117-4a9b-bb1e-7af75e471892"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "def1ac76-f3fe-4ca6-9af9-b5cc1e679591",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "01955393-05b9-468a-a743-548d47089940"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "77f3fb72-47c9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "b76a7a12-36fc-42b0-a70e-c8ca67ef3a5e",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "d1161110-eb1d-43c0-b63e-b801761f4619"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "01955393-05b9-468a-a743-548d47089940",
+                    "edgeid": "e16f94a6-465d-4d86-841c-a6c9120bbc1e",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "77f3fb73-47c9-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "51869586-6c34-4e54-abe8-c3c89a7e0ad5",
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "06ef2121-20d3-4c77-bcd4-49b1dc0ff090"
                 }
             ],
             "functions_x_graphs": [
@@ -43431,12 +43637,6 @@
                     "legacygroupid": null,
                     "nodegroupid": "05eb4710-cc2c-11ea-8733-3af9d3b32b71",
                     "parentnodegroup_id": "54a57d3c-bbd1-11ea-ad92-3af9d3b32b71"
-                },
-                {
-                    "cardinality": "1",
-                    "legacygroupid": null,
-                    "nodegroupid": "078be4c2-4be9-11ee-8a8d-11afefc4bff7",
-                    "parentnodegroup_id": null
                 },
                 {
                     "cardinality": "1",
@@ -43923,12 +44123,6 @@
                     "legacygroupid": null,
                     "nodegroupid": "6867bd48-47c9-11ee-8a8d-11afefc4bff7",
                     "parentnodegroup_id": "6867bd45-47c9-11ee-8a8d-11afefc4bff7"
-                },
-                {
-                    "cardinality": "1",
-                    "legacygroupid": null,
-                    "nodegroupid": "6a0bb6be-4be8-11ee-8a8d-11afefc4bff7",
-                    "parentnodegroup_id": null
                 },
                 {
                     "cardinality": "1",
@@ -48550,7 +48744,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "acquisition_identifier_data_assignment_statement_name_language",
+                    "alias": "acquisition_identifier_data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -48564,7 +48758,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "acquisition_identifier_data_assignment_statement_name_language",
+                    "name": "acquisition_identifier_data_assignment_statement_name_language_1",
                     "nodegroup_id": "30766bf4-472b-11ee-8a8d-11afefc4bff7",
                     "nodeid": "30766bf5-472b-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -52201,7 +52395,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "rights_acquisition_data_assignment_statement_name_content",
+                    "alias": "rights_acquisition_data_assignment_statement_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -52213,7 +52407,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "rights_acquisition_data_assignment_statement_name_content",
+                    "name": "rights_acquisition_data_assignment_statement_name_content_1",
                     "nodegroup_id": "5661f2c2-4bd3-11ee-8a8d-11afefc4bff7",
                     "nodeid": "5661f2bb-4bd3-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -52331,7 +52525,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "rights_acquisition_data_assignment_statement_type_metatype",
+                    "alias": "rights_acquisition_data_assignment_statement_type_metatype_1",
                     "config": {
                         "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
                     },
@@ -52345,7 +52539,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "rights_acquisition_data_assignment_statement_type_metatype",
+                    "name": "rights_acquisition_data_assignment_statement_type_metatype_1",
                     "nodegroup_id": "5661f2bf-4bd3-11ee-8a8d-11afefc4bff7",
                     "nodeid": "5661f2c1-4bd3-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -55544,7 +55738,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "move_identifier_data_assignment_statement_content",
+                    "alias": "move_identifier_data_assignment_statement_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -55556,7 +55750,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "move_identifier_data_assignment_statement_content",
+                    "name": "move_identifier_data_assignment_statement_content_1",
                     "nodegroup_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "77f3fb4d-47c9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -55632,7 +55826,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "move_identifier_data_assignment_statement_language",
+                    "alias": "move_identifier_data_assignment_statement_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -55646,7 +55840,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "move_identifier_data_assignment_statement_language",
+                    "name": "move_identifier_data_assignment_statement_language_1",
                     "nodegroup_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "77f3fb51-47c9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -56257,7 +56451,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "move_identifier_data_assignment_statement_name_content",
+                    "alias": "move_identifier_data_assignment_statement_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -56269,7 +56463,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "move_identifier_data_assignment_statement_name_content",
+                    "name": "move_identifier_data_assignment_statement_name_content_1",
                     "nodegroup_id": "77f3fb74-47c9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "77f3fb6d-47c9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -56364,7 +56558,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "move_identifier_data_assignment_statement_type",
+                    "alias": "move_identifier_data_assignment_statement_type_1",
                     "config": {
                         "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
                     },
@@ -56378,7 +56572,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "move_identifier_data_assignment_statement_type",
+                    "name": "move_identifier_data_assignment_statement_type_1",
                     "nodegroup_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "77f3fb72-47c9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -56431,7 +56625,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "move_identifier_data_assignment_statement_name_language",
+                    "alias": "move_identifier_data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -56445,7 +56639,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "move_identifier_data_assignment_statement_name_language",
+                    "name": "move_identifier_data_assignment_statement_name_language_1",
                     "nodegroup_id": "77f3fb74-47c9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "77f3fb75-47c9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -72608,6 +72802,603 @@
                     "nodeid": "fe72ff76-bbcf-11ea-ad92-3af9d3b32b71",
                     "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P90a_has_lower_value_limit",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "acquisition_identifier_data_assignment_statement_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "acquisition_identifier_data_assignment_statement_content_1",
+                    "nodegroup_id": "30766bf1-472b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "a32dc20b-4731-4069-bee2-e80124a0911e",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "acquisition_identifier_data_assignment_statement_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "acquisition_identifier_data_assignment_statement_label_1",
+                    "nodegroup_id": "30766bf1-472b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "ecd63fa9-7d83-49d6-90ca-4067c70ff8bf",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "acquisition_identifier_data_assignment_statement_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "acquisition_identifier_data_assignment_statement_language_1",
+                    "nodegroup_id": "30766bf1-472b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "c4b49865-61ab-46c3-a492-f3d3432aed1b",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "acquisition_identifier_data_assignment_statement_name_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "acquisition_identifier_data_assignment_statement_name_label_1",
+                    "nodegroup_id": "30766bf4-472b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "702e963d-ad95-49ae-8317-4bce37a84a2e",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "acquisition_identifier_data_assignment_statement_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "acquisition_identifier_data_assignment_statement_name_type_1",
+                    "nodegroup_id": "30766bf4-472b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "39893056-3aba-4e38-b279-93dff7d30d39",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "acquisition_identifier_data_assignment_statement_name_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "acquisition_identifier_data_assignment_statement_name_content_1",
+                    "nodegroup_id": "30766bf4-472b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "b687bf04-7b38-409c-9867-5706f871044c",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "acquisition_identifier_data_assignment_statement_type_1",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "acquisition_identifier_data_assignment_statement_type_1",
+                    "nodegroup_id": "30766bf1-472b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "97e9d893-33b4-48b4-9733-8022e0166cda",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "acquisition_identifier_data_assignment_statement_type_metatype_1",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "acquisition_identifier_data_assignment_statement_type_metatype_1",
+                    "nodegroup_id": "30766bf1-472b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "e4d5812e-6284-43f3-a1f0-7d45d9a9d010",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "acquisition_identifier_data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "acquisition_identifier_data_assignment_statement_name_language",
+                    "nodegroup_id": "30766bf4-472b-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "26f34b22-d48d-43c9-b0aa-d2f6dd513ea4",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "rights_acquisition_data_assignment_statement_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "rights_acquisition_data_assignment_statement_content_1",
+                    "nodegroup_id": "5661f2bf-4bd3-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "980009e5-d3ff-4963-9146-25254da37ab6",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "rights_acquisition_data_assignment_statement_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "rights_acquisition_data_assignment_statement_label_1",
+                    "nodegroup_id": "5661f2bf-4bd3-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "e7cafe06-e67b-4fa2-b9e5-2a9852aab17b",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "rights_acquisition_data_assignment_statement_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "rights_acquisition_data_assignment_statement_language_1",
+                    "nodegroup_id": "5661f2bf-4bd3-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "a3de4993-119f-4ba7-b6cf-d10914bb4368",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "rights_acquisition_data_assignment_statement_name_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "rights_acquisition_data_assignment_statement_name_label_1",
+                    "nodegroup_id": "5661f2c2-4bd3-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "96e62b09-5f86-4617-9b18-ab4adf436c85",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "rights_acquisition_data_assignment_statement_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "rights_acquisition_data_assignment_statement_name_type_1",
+                    "nodegroup_id": "5661f2c2-4bd3-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "da3cb647-9462-4f01-8a94-4078ec1bfebc",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "rights_acquisition_data_assignment_statement_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "rights_acquisition_data_assignment_statement_name_content",
+                    "nodegroup_id": "5661f2c2-4bd3-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "3c98db5d-5c59-4805-8a6c-9038d5296241",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "rights_acquisition_data_assignment_statement_type_1",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "rights_acquisition_data_assignment_statement_type_1",
+                    "nodegroup_id": "5661f2bf-4bd3-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "84d45ce0-18f6-488b-8fc9-405aa46a923f",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "rights_acquisition_data_assignment_statement_type_metatype",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "rights_acquisition_data_assignment_statement_type_metatype",
+                    "nodegroup_id": "5661f2bf-4bd3-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "2247da2b-6922-438a-81b6-d7706e6ef3aa",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "rights_acquisition_data_assignment_statement_name_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "rights_acquisition_data_assignment_statement_name_language_1",
+                    "nodegroup_id": "5661f2c2-4bd3-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "6d28ffe0-3b3e-4671-a82d-ff4ca6abbebf",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "move_identifier_data_assignment_statement_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "move_identifier_data_assignment_statement_content",
+                    "nodegroup_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "35262508-10c0-45ff-9a8c-7273d651fa2f",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "move_identifier_data_assignment_statement_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "move_identifier_data_assignment_statement_label_1",
+                    "nodegroup_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "d810d16b-d117-4a9b-bb1e-7af75e471892",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "move_identifier_data_assignment_statement_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "move_identifier_data_assignment_statement_language",
+                    "nodegroup_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "06ef2121-20d3-4c77-bcd4-49b1dc0ff090",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "move_identifier_data_assignment_statement_name_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "move_identifier_data_assignment_statement_name_label_1",
+                    "nodegroup_id": "77f3fb74-47c9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "ee402c53-3236-4959-bf80-ffb07cc574fc",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "move_identifier_data_assignment_statement_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "move_identifier_data_assignment_statement_name_type_1",
+                    "nodegroup_id": "77f3fb74-47c9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "d57e4c85-bd11-48ed-af5d-8c71228af7e4",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "move_identifier_data_assignment_statement_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "move_identifier_data_assignment_statement_name_content",
+                    "nodegroup_id": "77f3fb74-47c9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "5ca3ee0c-5431-4fd0-930a-308b9f25939b",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "move_identifier_data_assignment_statement_type",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "move_identifier_data_assignment_statement_type",
+                    "nodegroup_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "01955393-05b9-468a-a743-548d47089940",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "move_identifier_data_assignment_statement_type_metatype_1",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "move_identifier_data_assignment_statement_type_metatype_1",
+                    "nodegroup_id": "77f3fb71-47c9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "d1161110-eb1d-43c0-b63e-b801761f4619",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "move_identifier_data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "3d461890-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "move_identifier_data_assignment_statement_name_language",
+                    "nodegroup_id": "77f3fb74-47c9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "3e93c99f-23a9-4702-8237-c35d84124af9",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 }

--- a/graphs/resource_models/Set.json
+++ b/graphs/resource_models/Set.json
@@ -1919,7 +1919,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "7be90928-200b-11ee-9071-214dbb482912",
+                    "node_id": "ae9ad865-c8eb-48b6-a1cb-ae1b1545f595",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -1941,7 +1941,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "7be9092d-200b-11ee-9071-214dbb482912",
+                    "node_id": "3af3e603-0194-4a21-866d-5cc22284d822",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -1970,7 +1970,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "7be9092a-200b-11ee-9071-214dbb482912",
+                    "node_id": "3835c5a4-e299-4696-ae52-8a9678406c20",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -1999,7 +1999,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "7be9092b-200b-11ee-9071-214dbb482912",
+                    "node_id": "6e6f65dd-3b54-405c-bd27-ad92dcfbb5cb",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -5777,7 +5777,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "e4427a32-3566-11ee-8a8d-11afefc4bff7",
+                    "node_id": "eac31861-cf62-4aca-838f-d7b315b58eb8",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -5806,7 +5806,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "e4427a35-3566-11ee-8a8d-11afefc4bff7",
+                    "node_id": "b7e60701-5438-45f9-85d9-ea9f589b3df2",
                     "sortorder": 4,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -5828,7 +5828,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "e4427a36-3566-11ee-8a8d-11afefc4bff7",
+                    "node_id": "6c01fd68-03fa-4cbc-ac05-05c0e67626e9",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -5857,7 +5857,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "e4427a4a-3566-11ee-8a8d-11afefc4bff7",
+                    "node_id": "df55683d-20f5-4155-b739-fc60a36f1303",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -5879,7 +5879,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "e4427a51-3566-11ee-8a8d-11afefc4bff7",
+                    "node_id": "dda79892-b456-4b1e-a854-3d81e2e7517d",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -5908,7 +5908,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "e4427a52-3566-11ee-8a8d-11afefc4bff7",
+                    "node_id": "af09ddea-73d7-4738-b79c-8153d5c51746",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -5930,7 +5930,7 @@
                     "label": {
                         "en": "Statement Type"
                     },
-                    "node_id": "e4427a57-3566-11ee-8a8d-11afefc4bff7",
+                    "node_id": "67e33455-2fde-4727-877e-c24bc85e616f",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -5952,7 +5952,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "e4427a58-3566-11ee-8a8d-11afefc4bff7",
+                    "node_id": "e0f4a7fe-1bfa-4a50-ac84-dd0e1e7870b5",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -5974,7 +5974,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "e4427a5a-3566-11ee-8a8d-11afefc4bff7",
+                    "node_id": "58e16d34-9067-4fe4-9ecb-5060db7395a7",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6461,7 +6461,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "7be90923-200b-11ee-9071-214dbb482912",
+                    "node_id": "9bc2a303-881e-4081-8f98-eeae1a34f6bb",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -6483,7 +6483,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "7be90928-200b-11ee-9071-214dbb482912",
+                    "node_id": "aa15b2f0-37f1-4556-ba7f-ab63eb506127",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6505,7 +6505,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "7be9092d-200b-11ee-9071-214dbb482912",
+                    "node_id": "59700620-967b-4540-8ef9-4c221b492ce8",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6527,7 +6527,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "7be9092f-200b-11ee-9071-214dbb482912",
+                    "node_id": "acfe0f01-d497-444f-a7fc-43ec0709347f",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6556,7 +6556,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "7be90920-200b-11ee-9071-214dbb482912",
+                    "node_id": "3356bf55-4246-4b17-b2e4-78646d821d36",
                     "sortorder": 4,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -6585,7 +6585,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "7be9092a-200b-11ee-9071-214dbb482912",
+                    "node_id": "541eed32-cc1f-480c-b83c-e6520b66b44a",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -6614,7 +6614,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "7be9092b-200b-11ee-9071-214dbb482912",
+                    "node_id": "cfed00d9-0efc-4d2f-86f8-d47561a3116d",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -6665,7 +6665,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "7be9091d-200b-11ee-9071-214dbb482912",
+                    "node_id": "fa14036f-768f-4a21-886b-31f61ed304e9",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6694,7 +6694,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "7be9092e-200b-11ee-9071-214dbb482912",
+                    "node_id": "b3af4eed-dc50-47a5-928c-1567d3f5a654",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -6716,7 +6716,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "7be90904-200b-11ee-9071-214dbb482912",
+                    "node_id": "97de2cb2-a417-42f3-bce6-ba418c195627",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -6745,7 +6745,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "7be90905-200b-11ee-9071-214dbb482912",
+                    "node_id": "ee128938-ee14-4b01-b77a-6999c7c03c2f",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -6817,7 +6817,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "7be90903-200b-11ee-9071-214dbb482912",
+                    "node_id": "8f752526-1f3d-4787-bc8e-5e0d337943aa",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -6839,7 +6839,7 @@
                     "label": {
                         "en": "Statement Type"
                     },
-                    "node_id": "7be90915-200b-11ee-9071-214dbb482912",
+                    "node_id": "09d045bf-7766-4281-889c-66019490a81e",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -13026,6 +13026,258 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
                     "rangenode_id": "fc342d16-40e2-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90902-200b-11ee-9071-214dbb482912",
+                    "edgeid": "3a0aa780-0146-4715-9a36-cc62f345db14",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "8f752526-1f3d-4787-bc8e-5e0d337943aa"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90902-200b-11ee-9071-214dbb482912",
+                    "edgeid": "10a87d50-90cb-4ea7-ade7-5815a3f494d5",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "97de2cb2-a417-42f3-bce6-ba418c195627"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90902-200b-11ee-9071-214dbb482912",
+                    "edgeid": "345bedaf-82bb-4092-bad9-f090be190b1f",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "ee128938-ee14-4b01-b77a-6999c7c03c2f"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90902-200b-11ee-9071-214dbb482912",
+                    "edgeid": "3e41eeaa-c573-4745-8b63-0f4ead648f1a",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "acfe0f01-d497-444f-a7fc-43ec0709347f"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90913-200b-11ee-9071-214dbb482912",
+                    "edgeid": "1542e54b-8bb7-40dd-b710-98087ee3a8dd",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "fa14036f-768f-4a21-886b-31f61ed304e9"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90913-200b-11ee-9071-214dbb482912",
+                    "edgeid": "a24ecdd9-a561-4992-8400-3831bf92cd23",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "3356bf55-4246-4b17-b2e4-78646d821d36"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90913-200b-11ee-9071-214dbb482912",
+                    "edgeid": "b9850390-2dfd-480c-a780-ebf4dfeb93c7",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "09d045bf-7766-4281-889c-66019490a81e"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90915-200b-11ee-9071-214dbb482912",
+                    "edgeid": "c2403878-660b-4962-ac61-44337d563563",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "9bc2a303-881e-4081-8f98-eeae1a34f6bb"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "09d045bf-7766-4281-889c-66019490a81e",
+                    "edgeid": "997c077f-d2b6-4055-9eca-88afaa13354d",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "7be90923-200b-11ee-9071-214dbb482912"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "edgeid": "12e59d20-4a7d-4005-bd1a-8a6238ed866d",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "aa15b2f0-37f1-4556-ba7f-ab63eb506127"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "edgeid": "3fc08c53-6fe4-45ef-82d4-4016d23bb599",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "ae9ad865-c8eb-48b6-a1cb-ae1b1545f595"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "edgeid": "4174c182-c060-4690-854c-8f863a13b36c",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "541eed32-cc1f-480c-b83c-e6520b66b44a"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "edgeid": "bdefa1f8-6953-4f5f-bc50-e783bf9d4e8c",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "3835c5a4-e299-4696-ae52-8a9678406c20"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "edgeid": "adba07ce-f1cd-41fa-be4a-15e60689fb0d",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "cfed00d9-0efc-4d2f-86f8-d47561a3116d"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "edgeid": "889c988b-fe13-45f3-974d-4f3f3379af4c",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "6e6f65dd-3b54-405c-bd27-ad92dcfbb5cb"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "edgeid": "db2a55b2-bef6-4d80-b1a4-1afb935d34fc",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "59700620-967b-4540-8ef9-4c221b492ce8"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "edgeid": "72beca02-ef7b-4576-9d2b-c61f30dce709",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "3af3e603-0194-4a21-866d-5cc22284d822"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7be90913-200b-11ee-9071-214dbb482912",
+                    "edgeid": "e88be5b6-7ea0-4977-a87e-63f434870786",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "b3af4eed-dc50-47a5-928c-1567d3f5a654"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "66e543ca-6d07-426e-a13e-bfe0e5ced614",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "58e16d34-9067-4fe4-9ecb-5060db7395a7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "f77f1c43-51eb-4d2f-93a9-584365001396",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "df55683d-20f5-4155-b739-fc60a36f1303"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "c182b2f8-3ef8-4ea8-9a3b-63d4b94e45a5",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "af09ddea-73d7-4738-b79c-8153d5c51746"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "1d68014e-b21e-421c-b059-60c9ae7cb4bb",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "dda79892-b456-4b1e-a854-3d81e2e7517d"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "b03dfe0c-5246-499e-b657-54ce098e3da5",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "eac31861-cf62-4aca-838f-d7b315b58eb8"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "abbb7483-0ecd-477b-ba8c-a509d7f18b09",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "b7e60701-5438-45f9-85d9-ea9f589b3df2"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "8a353134-2f2a-4b37-8389-3d5f4378070d",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "67e33455-2fde-4727-877e-c24bc85e616f"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e4427a57-3566-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "6b9b23df-3618-44bc-b1e2-fb0680ac6cfd",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "e0f4a7fe-1bfa-4a50-ac84-dd0e1e7870b5"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "67e33455-2fde-4727-877e-c24bc85e616f",
+                    "edgeid": "1c160f62-e879-422e-940e-5d5d7be8c578",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "e4427a58-3566-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "9f9b6cb9-55d7-4e86-a503-79dc7e5538f9",
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "6c01fd68-03fa-4cbc-ac05-05c0e67626e9"
                 }
             ],
             "functions_x_graphs": [
@@ -17113,7 +17365,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_type",
+                    "alias": "data_assignment_statement_type_1",
                     "config": {
                         "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
                     },
@@ -17127,7 +17379,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_type",
+                    "name": "data_assignment_statement_type_1",
                     "nodegroup_id": "7be90913-200b-11ee-9071-214dbb482912",
                     "nodeid": "7be90915-200b-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -17356,7 +17608,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_label",
+                    "alias": "data_assignment_statement_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -17368,7 +17620,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_label",
+                    "name": "data_assignment_statement_label_1",
                     "nodegroup_id": "7be90913-200b-11ee-9071-214dbb482912",
                     "nodeid": "7be90920-200b-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -17580,7 +17832,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_name_label",
+                    "alias": "data_assignment_statement_name_label_2",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -17592,7 +17844,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_name_label",
+                    "name": "data_assignment_statement_name_label_2",
                     "nodegroup_id": "7be90925-200b-11ee-9071-214dbb482912",
                     "nodeid": "7be9092a-200b-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -17601,7 +17853,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_name_content",
+                    "alias": "data_assignment_statement_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -17613,7 +17865,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_name_content",
+                    "name": "data_assignment_statement_name_content_1",
                     "nodegroup_id": "7be90925-200b-11ee-9071-214dbb482912",
                     "nodeid": "7be9092b-200b-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -17645,7 +17897,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_name_type",
+                    "alias": "data_assignment_statement_name_type_2",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -17659,7 +17911,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_name_type",
+                    "name": "data_assignment_statement_name_type_2",
                     "nodegroup_id": "7be90925-200b-11ee-9071-214dbb482912",
                     "nodeid": "7be9092d-200b-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -20198,7 +20450,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "creation_identifier_data_assignment_statement_label",
+                    "alias": "creation_identifier_data_assignment_statement_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -20210,7 +20462,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "creation_identifier_data_assignment_statement_label",
+                    "name": "creation_identifier_data_assignment_statement_label_1",
                     "nodegroup_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
                     "nodeid": "e4427a35-3566-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -20219,7 +20471,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "creation_identifier_data_assignment_statement_language",
+                    "alias": "creation_identifier_data_assignment_statement_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -20233,7 +20485,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "creation_identifier_data_assignment_statement_language",
+                    "name": "creation_identifier_data_assignment_statement_language_1",
                     "nodegroup_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
                     "nodeid": "e4427a36-3566-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -20657,7 +20909,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "creation_identifier_data_assignment_statement_name_label",
+                    "alias": "creation_identifier_data_assignment_statement_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -20669,7 +20921,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "creation_identifier_data_assignment_statement_name_label",
+                    "name": "creation_identifier_data_assignment_statement_name_label_1",
                     "nodegroup_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
                     "nodeid": "e4427a4a-3566-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -20821,7 +21073,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "creation_identifier_data_assignment_statement_name_type",
+                    "alias": "creation_identifier_data_assignment_statement_name_type_1",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -20835,7 +21087,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "creation_identifier_data_assignment_statement_name_type",
+                    "name": "creation_identifier_data_assignment_statement_name_type_1",
                     "nodegroup_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
                     "nodeid": "e4427a51-3566-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -20844,7 +21096,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "creation_identifier_data_assignment_statement_name_content",
+                    "alias": "creation_identifier_data_assignment_statement_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -20856,7 +21108,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "creation_identifier_data_assignment_statement_name_content",
+                    "name": "creation_identifier_data_assignment_statement_name_content_1",
                     "nodegroup_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
                     "nodeid": "e4427a52-3566-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -20951,7 +21203,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "creation_identifier_data_assignment_statement_type",
+                    "alias": "creation_identifier_data_assignment_statement_type_1",
                     "config": {
                         "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
                     },
@@ -20965,7 +21217,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "creation_identifier_data_assignment_statement_type",
+                    "name": "creation_identifier_data_assignment_statement_type_1",
                     "nodegroup_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
                     "nodeid": "e4427a57-3566-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -20974,7 +21226,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "creation_identifier_data_assignment_statement_type_metatype",
+                    "alias": "creation_identifier_data_assignment_statement_type_metatype_1",
                     "config": {
                         "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
                     },
@@ -20988,7 +21240,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "creation_identifier_data_assignment_statement_type_metatype",
+                    "name": "creation_identifier_data_assignment_statement_type_metatype_1",
                     "nodegroup_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
                     "nodeid": "e4427a58-3566-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -21018,7 +21270,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "creation_identifier_data_assignment_statement_name_language",
+                    "alias": "creation_identifier_data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -21032,7 +21284,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "creation_identifier_data_assignment_statement_name_language",
+                    "name": "creation_identifier_data_assignment_statement_name_language_1",
                     "nodegroup_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
                     "nodeid": "e4427a5a-3566-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -21388,6 +21640,580 @@
                     "nodeid": "fc342d16-40e2-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E33_Linguistic_Object",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_label_1",
+                    "nodegroup_id": "7be90902-200b-11ee-9071-214dbb482912",
+                    "nodeid": "8f752526-1f3d-4787-bc8e-5e0d337943aa",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_type_1",
+                    "nodegroup_id": "7be90902-200b-11ee-9071-214dbb482912",
+                    "nodeid": "97de2cb2-a417-42f3-bce6-ba418c195627",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_content_1",
+                    "nodegroup_id": "7be90902-200b-11ee-9071-214dbb482912",
+                    "nodeid": "ee128938-ee14-4b01-b77a-6999c7c03c2f",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_type",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_type",
+                    "nodegroup_id": "7be90913-200b-11ee-9071-214dbb482912",
+                    "nodeid": "09d045bf-7766-4281-889c-66019490a81e",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_language_1",
+                    "nodegroup_id": "7be90913-200b-11ee-9071-214dbb482912",
+                    "nodeid": "fa14036f-768f-4a21-886b-31f61ed304e9",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_label",
+                    "nodegroup_id": "7be90913-200b-11ee-9071-214dbb482912",
+                    "nodeid": "3356bf55-4246-4b17-b2e4-78646d821d36",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_type_metatype_1",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_type_metatype_1",
+                    "nodegroup_id": "7be90913-200b-11ee-9071-214dbb482912",
+                    "nodeid": "9bc2a303-881e-4081-8f98-eeae1a34f6bb",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_language_1",
+                    "nodegroup_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "nodeid": "aa15b2f0-37f1-4556-ba7f-ab63eb506127",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_language_2",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_language_2",
+                    "nodegroup_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "nodeid": "ae9ad865-c8eb-48b6-a1cb-ae1b1545f595",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_label_1",
+                    "nodegroup_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "nodeid": "541eed32-cc1f-480c-b83c-e6520b66b44a",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_label",
+                    "nodegroup_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "nodeid": "3835c5a4-e299-4696-ae52-8a9678406c20",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_content_2",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_content_2",
+                    "nodegroup_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "nodeid": "cfed00d9-0efc-4d2f-86f8-d47561a3116d",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_content",
+                    "nodegroup_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "nodeid": "6e6f65dd-3b54-405c-bd27-ad92dcfbb5cb",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_type_1",
+                    "nodegroup_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "nodeid": "59700620-967b-4540-8ef9-4c221b492ce8",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_type",
+                    "nodegroup_id": "7be90925-200b-11ee-9071-214dbb482912",
+                    "nodeid": "3af3e603-0194-4a21-866d-5cc22284d822",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_content_1",
+                    "nodegroup_id": "7be90913-200b-11ee-9071-214dbb482912",
+                    "nodeid": "b3af4eed-dc50-47a5-928c-1567d3f5a654",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_language_1",
+                    "nodegroup_id": "7be90902-200b-11ee-9071-214dbb482912",
+                    "nodeid": "acfe0f01-d497-444f-a7fc-43ec0709347f",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_data_assignment_statement_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_data_assignment_statement_content_1",
+                    "nodegroup_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "eac31861-cf62-4aca-838f-d7b315b58eb8",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_data_assignment_statement_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_data_assignment_statement_label",
+                    "nodegroup_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "b7e60701-5438-45f9-85d9-ea9f589b3df2",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_data_assignment_statement_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_data_assignment_statement_language",
+                    "nodegroup_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "6c01fd68-03fa-4cbc-ac05-05c0e67626e9",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_data_assignment_statement_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_data_assignment_statement_name_label",
+                    "nodegroup_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "df55683d-20f5-4155-b739-fc60a36f1303",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_data_assignment_statement_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_data_assignment_statement_name_type",
+                    "nodegroup_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "dda79892-b456-4b1e-a854-3d81e2e7517d",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_data_assignment_statement_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_data_assignment_statement_name_content",
+                    "nodegroup_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "af09ddea-73d7-4738-b79c-8153d5c51746",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_data_assignment_statement_type",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_data_assignment_statement_type",
+                    "nodegroup_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "67e33455-2fde-4727-877e-c24bc85e616f",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_data_assignment_statement_type_metatype",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_data_assignment_statement_type_metatype",
+                    "nodegroup_id": "e4427a56-3566-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "e0f4a7fe-1bfa-4a50-ac84-dd0e1e7870b5",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "bdba56bc-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_data_assignment_statement_name_language",
+                    "nodegroup_id": "e4427a59-3566-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "58e16d34-9067-4fe4-9ecb-5060db7395a7",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 }

--- a/graphs/resource_models/Textual Work.json
+++ b/graphs/resource_models/Textual Work.json
@@ -2839,9 +2839,7 @@
                 {
                     "card_id": "1c7e9236-bbd6-11ea-b6b2-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -3895,7 +3893,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "f9dbfdfa-40e9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "12f21d73-74c7-47ec-9d18-e72559ad18cb",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3924,7 +3922,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "f9dbfdfe-40e9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "4b9f5427-fe97-4bbf-87e6-f4108bc14afb",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3946,7 +3944,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "f9dbfe10-40e9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "0c19168b-4635-4262-bbcc-d0919a12b856",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -3975,7 +3973,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "f9dbfe12-40e9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "08a2743f-87e3-4d03-9a76-7ece126efe25",
                     "sortorder": 4,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3997,7 +3995,7 @@
                     "label": {
                         "en": "Statement Type"
                     },
-                    "node_id": "f9dbfe13-40e9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "2c6f14a8-be93-426c-871c-aa7bb6bdae67",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4019,7 +4017,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "f9dbfe16-40e9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "cb83ba65-ae23-4121-8b4a-c6ce5b5f1db4",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4048,7 +4046,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "f9dbfe17-40e9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "9a8a8bb2-b9cd-4a78-a75b-e7b3cd1dae14",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4070,7 +4068,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "f9dbfe18-40e9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "2fb67d76-6592-4f27-bbef-7c112a64a7f4",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4092,7 +4090,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "f9dbfe19-40e9-11ee-8a8d-11afefc4bff7",
+                    "node_id": "a9cbb2e5-eca8-4d39-bce7-83207f6f0e82",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6408,7 +6406,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "f0aedf56-356d-11ee-8a8d-11afefc4bff7",
+                    "node_id": "9bd74abe-f6b0-433d-bba0-60886f4f2ac3",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6437,7 +6435,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "f0aedf57-356d-11ee-8a8d-11afefc4bff7",
+                    "node_id": "73ee5f12-9741-4fb5-a1e8-8ec1a04b937a",
                     "sortorder": 4,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -6459,7 +6457,7 @@
                     "label": {
                         "en": "Statement Type"
                     },
-                    "node_id": "f0aedf5a-356d-11ee-8a8d-11afefc4bff7",
+                    "node_id": "d1154729-8c6c-4bbd-b8f3-2fee1f2923bc",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6488,7 +6486,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "f0aedf68-356d-11ee-8a8d-11afefc4bff7",
+                    "node_id": "98651af2-b66b-4240-98a0-22a77de49919",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -6510,7 +6508,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "f0aedf85-356d-11ee-8a8d-11afefc4bff7",
+                    "node_id": "f7c1eab4-e0d0-4d1c-bd05-b1015e97bac7",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -8859,7 +8857,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "f0aedf77-356d-11ee-8a8d-11afefc4bff7",
+                    "node_id": "f536d80e-d2de-4f94-90f3-64daf3d3cd35",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -8903,7 +8901,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "f0aedf87-356d-11ee-8a8d-11afefc4bff7",
+                    "node_id": "36673dc2-c2c2-4aa9-bcce-241e1fc1c323",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -8932,7 +8930,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "f0aedf88-356d-11ee-8a8d-11afefc4bff7",
+                    "node_id": "6e646973-5a3c-4f77-9b33-3ef268987a0f",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -8954,7 +8952,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "f0aedf89-356d-11ee-8a8d-11afefc4bff7",
+                    "node_id": "38623334-21fb-406d-bdcc-31ca02397cdb",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -17489,6 +17487,186 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P141i_was_assigned_by",
                     "rangenode_id": "f9dbfde1-40e9-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f0aedf86-356d-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "c854d9d8-52f1-4a8a-a05a-72b5c260198b",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "38623334-21fb-406d-bdcc-31ca02397cdb"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f0aedf86-356d-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "06eb2286-8bfd-4bd3-ac31-342a821a572b",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "f536d80e-d2de-4f94-90f3-64daf3d3cd35"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f0aedf86-356d-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "019dbf3e-f2be-4800-9c0c-ef5698767bf8",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "6e646973-5a3c-4f77-9b33-3ef268987a0f"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f0aedf86-356d-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "c3534db9-afe8-4ef3-a5c6-a21098565976",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "36673dc2-c2c2-4aa9-bcce-241e1fc1c323"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "d65c2351-4117-4123-a6aa-95d020347434",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "98651af2-b66b-4240-98a0-22a77de49919"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "c897a9f1-13a6-4d47-9307-2eb5bd7547c6",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "9bd74abe-f6b0-433d-bba0-60886f4f2ac3"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "8ccf5d3c-33ab-4ca5-8778-56f5353d773a",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "d1154729-8c6c-4bbd-b8f3-2fee1f2923bc"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f0aedf5a-356d-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "9266edd6-3af1-47ac-99c8-642a63ca0a5e",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "f7c1eab4-e0d0-4d1c-bd05-b1015e97bac7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "d1154729-8c6c-4bbd-b8f3-2fee1f2923bc",
+                    "edgeid": "35a76ee3-c234-4288-aca7-46b0c6cfc644",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "f0aedf85-356d-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "2845f641-40f4-4162-be83-dcc1a0aeaa71",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "73ee5f12-9741-4fb5-a1e8-8ec1a04b937a"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "2d9768c9-db80-4511-89e6-d0e1220aac99",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "9a8a8bb2-b9cd-4a78-a75b-e7b3cd1dae14"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "406ae833-571e-4800-bad5-ee083f7f0abd",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "a9cbb2e5-eca8-4d39-bce7-83207f6f0e82"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "7f7fd166-41a3-4224-84f2-5dc831a284c0",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "12f21d73-74c7-47ec-9d18-e72559ad18cb"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "5d0cc26d-f809-4f1f-8b66-0a0b60f595cc",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "4b9f5427-fe97-4bbf-87e6-f4108bc14afb"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "0ad5bf94-facd-4c1e-93b2-33ba182834a3",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "cb83ba65-ae23-4121-8b4a-c6ce5b5f1db4"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "d70ca028-bbad-420f-a972-01958da8b141",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "2c6f14a8-be93-426c-871c-aa7bb6bdae67"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f9dbfe13-40e9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "12d71aa1-b20b-4ecf-bf23-f617c0b327f7",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "0c19168b-4635-4262-bbcc-d0919a12b856"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "2c6f14a8-be93-426c-871c-aa7bb6bdae67",
+                    "edgeid": "703fd186-d69e-4d15-b53d-c5b6f70b7339",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "f9dbfe10-40e9-11ee-8a8d-11afefc4bff7"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "57051db5-2ff3-4be7-b767-f4f2a136fbb9",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "08a2743f-87e3-4d03-9a76-7ece126efe25"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "92d8c943-27bc-4570-ada6-09b2102c23a1",
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "2fb67d76-6592-4f27-bbef-7c112a64a7f4"
                 }
             ],
             "functions_x_graphs": [
@@ -25324,7 +25502,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "publication_identifier_data_assignment_statement_language",
+                    "alias": "publication_identifier_data_assignment_statement_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -25338,7 +25516,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "publication_identifier_data_assignment_statement_language",
+                    "name": "publication_identifier_data_assignment_statement_language_1",
                     "nodegroup_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f0aedf56-356d-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -25347,7 +25525,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "publication_identifier_data_assignment_statement_label",
+                    "alias": "publication_identifier_data_assignment_statement_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -25359,7 +25537,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "publication_identifier_data_assignment_statement_label",
+                    "name": "publication_identifier_data_assignment_statement_label_1",
                     "nodegroup_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f0aedf57-356d-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -25412,7 +25590,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "publication_identifier_data_assignment_statement_type",
+                    "alias": "publication_identifier_data_assignment_statement_type_1",
                     "config": {
                         "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
                     },
@@ -25426,7 +25604,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "publication_identifier_data_assignment_statement_type",
+                    "name": "publication_identifier_data_assignment_statement_type_1",
                     "nodegroup_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f0aedf5a-356d-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -25772,7 +25950,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "publication_identifier_data_assignment_statement_content",
+                    "alias": "publication_identifier_data_assignment_statement_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -25784,7 +25962,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "publication_identifier_data_assignment_statement_content",
+                    "name": "publication_identifier_data_assignment_statement_content_1",
                     "nodegroup_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f0aedf68-356d-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -26462,7 +26640,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "publication_identifier_data_assignment_statement_name_type",
+                    "alias": "publication_identifier_data_assignment_statement_name_type_1",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -26476,7 +26654,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "publication_identifier_data_assignment_statement_name_type",
+                    "name": "publication_identifier_data_assignment_statement_name_type_1",
                     "nodegroup_id": "f0aedf86-356d-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f0aedf87-356d-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -26485,7 +26663,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "publication_identifier_data_assignment_statement_name_content",
+                    "alias": "publication_identifier_data_assignment_statement_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -26497,7 +26675,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "publication_identifier_data_assignment_statement_name_content",
+                    "name": "publication_identifier_data_assignment_statement_name_content_1",
                     "nodegroup_id": "f0aedf86-356d-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f0aedf88-356d-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -26506,7 +26684,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "publication_identifier_data_assignment_statement_name_language",
+                    "alias": "publication_identifier_data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -26520,7 +26698,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "publication_identifier_data_assignment_statement_name_language",
+                    "name": "publication_identifier_data_assignment_statement_name_language_1",
                     "nodegroup_id": "f0aedf86-356d-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f0aedf89-356d-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -28188,7 +28366,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_content",
+                    "alias": "identifier_data_assignment_statement_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -28200,7 +28378,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_content",
+                    "name": "identifier_data_assignment_statement_name_content_1",
                     "nodegroup_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f9dbfdfa-40e9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -28276,7 +28454,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_label",
+                    "alias": "identifier_data_assignment_statement_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -28288,7 +28466,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_label",
+                    "name": "identifier_data_assignment_statement_name_label_1",
                     "nodegroup_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f9dbfdfe-40e9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -28685,7 +28863,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_type_metatype",
+                    "alias": "identifier_data_assignment_statement_type_metatype_1",
                     "config": {
                         "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
                     },
@@ -28699,7 +28877,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_type_metatype",
+                    "name": "identifier_data_assignment_statement_type_metatype_1",
                     "nodegroup_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f9dbfe10-40e9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -28731,7 +28909,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_label",
+                    "alias": "identifier_data_assignment_statement_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -28743,7 +28921,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_label",
+                    "name": "identifier_data_assignment_statement_label_1",
                     "nodegroup_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f9dbfe12-40e9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -28752,7 +28930,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_type",
+                    "alias": "identifier_data_assignment_statement_type_1",
                     "config": {
                         "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
                     },
@@ -28766,7 +28944,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_type",
+                    "name": "identifier_data_assignment_statement_type_1",
                     "nodegroup_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f9dbfe13-40e9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -28817,7 +28995,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_language",
+                    "alias": "identifier_data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -28831,7 +29009,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_language",
+                    "name": "identifier_data_assignment_statement_name_language_1",
                     "nodegroup_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f9dbfe16-40e9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -28840,7 +29018,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_content",
+                    "alias": "identifier_data_assignment_statement_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -28852,7 +29030,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_content",
+                    "name": "identifier_data_assignment_statement_content_1",
                     "nodegroup_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f9dbfe17-40e9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -28861,7 +29039,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_language",
+                    "alias": "identifier_data_assignment_statement_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -28875,7 +29053,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_language",
+                    "name": "identifier_data_assignment_statement_language_1",
                     "nodegroup_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f9dbfe18-40e9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -28884,7 +29062,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_type",
+                    "alias": "identifier_data_assignment_statement_name_type_1",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -28898,7 +29076,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_type",
+                    "name": "identifier_data_assignment_statement_name_type_1",
                     "nodegroup_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f9dbfe19-40e9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -29098,6 +29276,404 @@
                     "nodeid": "f9dbfe22-40e9-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_identifier_data_assignment_statement_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "publication_identifier_data_assignment_statement_language",
+                    "nodegroup_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "9bd74abe-f6b0-433d-bba0-60886f4f2ac3",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_identifier_data_assignment_statement_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "publication_identifier_data_assignment_statement_label",
+                    "nodegroup_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "73ee5f12-9741-4fb5-a1e8-8ec1a04b937a",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_identifier_data_assignment_statement_type",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "publication_identifier_data_assignment_statement_type",
+                    "nodegroup_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "d1154729-8c6c-4bbd-b8f3-2fee1f2923bc",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_identifier_data_assignment_statement_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "publication_identifier_data_assignment_statement_content",
+                    "nodegroup_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "98651af2-b66b-4240-98a0-22a77de49919",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_identifier_data_assignment_statement_name_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "publication_identifier_data_assignment_statement_name_label_1",
+                    "nodegroup_id": "f0aedf86-356d-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "f536d80e-d2de-4f94-90f3-64daf3d3cd35",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_identifier_data_assignment_statement_type_metatype_1",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "publication_identifier_data_assignment_statement_type_metatype_1",
+                    "nodegroup_id": "f0aedf59-356d-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "f7c1eab4-e0d0-4d1c-bd05-b1015e97bac7",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_identifier_data_assignment_statement_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "publication_identifier_data_assignment_statement_name_type",
+                    "nodegroup_id": "f0aedf86-356d-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "36673dc2-c2c2-4aa9-bcce-241e1fc1c323",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_identifier_data_assignment_statement_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "publication_identifier_data_assignment_statement_name_content",
+                    "nodegroup_id": "f0aedf86-356d-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "6e646973-5a3c-4f77-9b33-3ef268987a0f",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "publication_identifier_data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "publication_identifier_data_assignment_statement_name_language",
+                    "nodegroup_id": "f0aedf86-356d-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "38623334-21fb-406d-bdcc-31ca02397cdb",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_content",
+                    "nodegroup_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "12f21d73-74c7-47ec-9d18-e72559ad18cb",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_label",
+                    "nodegroup_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "4b9f5427-fe97-4bbf-87e6-f4108bc14afb",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_type_metatype",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_type_metatype",
+                    "nodegroup_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "0c19168b-4635-4262-bbcc-d0919a12b856",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_label",
+                    "nodegroup_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "08a2743f-87e3-4d03-9a76-7ece126efe25",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_type",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_type",
+                    "nodegroup_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "2c6f14a8-be93-426c-871c-aa7bb6bdae67",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_language",
+                    "nodegroup_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "cb83ba65-ae23-4121-8b4a-c6ce5b5f1db4",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_content",
+                    "nodegroup_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "9a8a8bb2-b9cd-4a78-a75b-e7b3cd1dae14",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_language",
+                    "nodegroup_id": "f9dbfe08-40e9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "2fb67d76-6592-4f27-bbef-7c112a64a7f4",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "6dad61aa-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_type",
+                    "nodegroup_id": "f9dbfe04-40e9-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "a9cbb2e5-eca8-4d39-bce7-83207f6f0e82",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 }

--- a/graphs/resource_models/Visual Work.json
+++ b/graphs/resource_models/Visual Work.json
@@ -2775,7 +2775,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "780b3923-2017-11ee-9071-214dbb482912",
+                    "node_id": "3b09a1e7-622b-48fa-ba2f-d0764091a660",
                     "sortorder": null,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -2797,7 +2797,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "780b3917-2017-11ee-9071-214dbb482912",
+                    "node_id": "bd890cc4-1e7d-4f73-86f9-7e564701d072",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -2826,7 +2826,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "780b38fd-2017-11ee-9071-214dbb482912",
+                    "node_id": "1291b2ea-d5a8-4f4e-a682-5eb2da03d300",
                     "sortorder": 4,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -2848,7 +2848,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "780b3927-2017-11ee-9071-214dbb482912",
+                    "node_id": "da75f196-abe1-49a1-90bd-1cbdb4b36480",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -2870,7 +2870,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "780b3909-2017-11ee-9071-214dbb482912",
+                    "node_id": "7b0538ae-3cde-4f11-9355-ad0f95b67922",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -2899,7 +2899,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "780b38ff-2017-11ee-9071-214dbb482912",
+                    "node_id": "bc419b8e-46b0-4b10-a081-809be67000cc",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -2928,7 +2928,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "780b390f-2017-11ee-9071-214dbb482912",
+                    "node_id": "80707243-5ce2-4f54-a147-ad824b3ee748",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -2950,7 +2950,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "780b392b-2017-11ee-9071-214dbb482912",
+                    "node_id": "abb31ded-dde5-4e84-a032-182b3db03ea1",
                     "sortorder": null,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -2972,7 +2972,7 @@
                     "label": {
                         "en": "Statement Type"
                     },
-                    "node_id": "780b3928-2017-11ee-9071-214dbb482912",
+                    "node_id": "fbd3393f-a9b9-47dc-b9d7-6d2c5ba8bcbd",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -3085,7 +3085,7 @@
                     "label": {
                         "en": "Statement Label"
                     },
-                    "node_id": "fa1a6dbc-2019-11ee-9071-214dbb482912",
+                    "node_id": "2953f318-e2e1-433a-a21c-1799c7a779dc",
                     "sortorder": 4,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3107,7 +3107,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "fa1a6dc4-2019-11ee-9071-214dbb482912",
+                    "node_id": "b41f2061-a1f1-4638-99f0-bc5723ba443c",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -3129,7 +3129,7 @@
                     "label": {
                         "en": "Statement Type"
                     },
-                    "node_id": "fa1a6db1-2019-11ee-9071-214dbb482912",
+                    "node_id": "7eee7dc8-ac11-4b36-8263-aef3f7bfdca8",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -3230,7 +3230,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "fa1a6dc7-2019-11ee-9071-214dbb482912",
+                    "node_id": "b878c7fd-acc1-4254-8683-f2f1c2e13a39",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3252,7 +3252,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "fa1a6dc9-2019-11ee-9071-214dbb482912",
+                    "node_id": "66c75e63-3a23-4292-844c-478c1dbc259b",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -3281,7 +3281,7 @@
                     "label": {
                         "en": "Statement"
                     },
-                    "node_id": "fa1a6dca-2019-11ee-9071-214dbb482912",
+                    "node_id": "d5711aa8-8977-4bd7-a6b4-04928c2d7a19",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3303,7 +3303,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "fa1a6dcb-2019-11ee-9071-214dbb482912",
+                    "node_id": "30d40039-4811-4fa3-bf86-0e4e40fd0af5",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -3332,7 +3332,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "fa1a6d9f-2019-11ee-9071-214dbb482912",
+                    "node_id": "02282c0b-5c99-4489-a329-709b85af830d",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3354,7 +3354,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "fa1a6da0-2019-11ee-9071-214dbb482912",
+                    "node_id": "e03d9302-8662-4bd3-8b3c-5dc2aacd39d5",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -3383,7 +3383,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "fa1a6da1-2019-11ee-9071-214dbb482912",
+                    "node_id": "b9763ff2-e4f8-4729-9fa1-e6ab89b514a6",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3405,7 +3405,7 @@
                     "label": {
                         "en": "Statement Type Metatype"
                     },
-                    "node_id": "fa1a6dbf-2019-11ee-9071-214dbb482912",
+                    "node_id": "4d488d1b-686f-4468-9e7b-090164c81584",
                     "sortorder": 2,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -3434,7 +3434,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "fa1a6dc6-2019-11ee-9071-214dbb482912",
+                    "node_id": "f891b264-3661-43b6-af1e-6ff609e454da",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -3456,7 +3456,7 @@
                     "label": {
                         "en": "Statement Language"
                     },
-                    "node_id": "fa1a6db9-2019-11ee-9071-214dbb482912",
+                    "node_id": "386e021c-481e-4456-bbbb-21ede27dc3db",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4350,7 +4350,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "780b3923-2017-11ee-9071-214dbb482912",
+                    "node_id": "be21da54-faa4-4f98-8ce0-02f81ca595f4",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4423,7 +4423,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "780b3927-2017-11ee-9071-214dbb482912",
+                    "node_id": "2303da18-1b56-4d5c-9d12-82084eadf641",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -4474,7 +4474,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "780b38ff-2017-11ee-9071-214dbb482912",
+                    "node_id": "b38f7f8b-69b3-4c76-a732-e1f70efdc98c",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -4525,7 +4525,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "780b392b-2017-11ee-9071-214dbb482912",
+                    "node_id": "e9526e3b-e7fa-4c79-8ac8-60ff3b09d48c",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6242,9 +6242,7 @@
                 {
                     "card_id": "d3dccfd6-bbd8-11ea-b6b2-3af9d3b32b71",
                     "config": {
-                        "defaultValue": [
-                            "8f40c740-3c02-4839-b1a4-f1460823a9fe"
-                        ],
+                        "defaultValue": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
@@ -6864,7 +6862,7 @@
                     "label": {
                         "en": "Name Type"
                     },
-                    "node_id": "780b3925-2017-11ee-9071-214dbb482912",
+                    "node_id": "fdcbcaa6-78aa-4b6c-90b8-54f3d4d66019",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6893,7 +6891,7 @@
                     "label": {
                         "en": "Name"
                     },
-                    "node_id": "780b3912-2017-11ee-9071-214dbb482912",
+                    "node_id": "75bfc094-64f3-4de9-a00a-36501ee59255",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -6915,7 +6913,7 @@
                     "label": {
                         "en": "Name Language"
                     },
-                    "node_id": "780b390a-2017-11ee-9071-214dbb482912",
+                    "node_id": "242c017a-fd13-4546-a176-031a073abde6",
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -6944,7 +6942,7 @@
                     "label": {
                         "en": "Name Label"
                     },
-                    "node_id": "780b3924-2017-11ee-9071-214dbb482912",
+                    "node_id": "56a9a8be-4dff-4cff-8468-2254a9a72534",
                     "sortorder": 3,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -9155,7 +9153,7 @@
                     "label": {
                         "en": "Identifier Type"
                     },
-                    "node_id": "f6360679-3574-11ee-8a8d-11afefc4bff7",
+                    "node_id": "1baf82fe-c12a-4c1c-9ef5-8c101f95f3f9",
                     "sortorder": 1,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000012"
@@ -9184,7 +9182,7 @@
                     "label": {
                         "en": "Identifier Label"
                     },
-                    "node_id": "f6360677-3574-11ee-8a8d-11afefc4bff7",
+                    "node_id": "fb9918c3-0f05-496e-aa2a-f4d4691676e5",
                     "sortorder": 3,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -9213,7 +9211,7 @@
                     "label": {
                         "en": "Identifier"
                     },
-                    "node_id": "f6360698-3574-11ee-8a8d-11afefc4bff7",
+                    "node_id": "4a791e4c-ed53-4ef8-be6f-9114439557ae",
                     "sortorder": 0,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
@@ -17705,6 +17703,321 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P140i_was_attributed_by",
                     "rangenode_id": "fa1a6d99-2019-11ee-9071-214dbb482912"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b3902-2017-11ee-9071-214dbb482912",
+                    "edgeid": "9fe7b5c1-ade3-4bef-8bda-70af6a1d7495",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "80707243-5ce2-4f54-a147-ad824b3ee748"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "edgeid": "bae08ffa-bfd9-45e1-9fc9-940ca679dfae",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "2303da18-1b56-4d5c-9d12-82084eadf641"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "edgeid": "5f21f519-15e8-4e6f-b03b-cacff1edcd93",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "da75f196-abe1-49a1-90bd-1cbdb4b36480"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b3902-2017-11ee-9071-214dbb482912",
+                    "edgeid": "1264b258-3b57-4695-b57e-a6d81b059d7a",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "1291b2ea-d5a8-4f4e-a682-5eb2da03d300"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "edgeid": "faca18e1-7f98-45a4-899c-e03a02dd40bc",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "b38f7f8b-69b3-4c76-a732-e1f70efdc98c"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "edgeid": "d8ef4caa-a06d-441c-8487-51fd8a51d4c3",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "bc419b8e-46b0-4b10-a081-809be67000cc"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b3928-2017-11ee-9071-214dbb482912",
+                    "edgeid": "e140cf03-f635-4526-8051-25cc49b6d2d6",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "7b0538ae-3cde-4f11-9355-ad0f95b67922"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fbd3393f-a9b9-47dc-b9d7-6d2c5ba8bcbd",
+                    "edgeid": "4eac4b83-6cdb-40f9-8034-0deffa70b09b",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "780b3909-2017-11ee-9071-214dbb482912"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "edgeid": "c0c1c4b9-eb53-45cc-8c67-80e1a0063949",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "be21da54-faa4-4f98-8ce0-02f81ca595f4"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "edgeid": "44857f72-baae-4aae-bb69-c87188c27b84",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "3b09a1e7-622b-48fa-ba2f-d0764091a660"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b3902-2017-11ee-9071-214dbb482912",
+                    "edgeid": "b91de492-ec30-45a5-8411-4b45d1725f02",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "fbd3393f-a9b9-47dc-b9d7-6d2c5ba8bcbd"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "edgeid": "d2b0b15d-3b8c-4f09-9ee5-c3b3a73235aa",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "e9526e3b-e7fa-4c79-8ac8-60ff3b09d48c"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "edgeid": "0b85b0b4-4def-4ea8-b141-17ca9137af8f",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "abb31ded-dde5-4e84-a032-182b3db03ea1"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b3908-2017-11ee-9071-214dbb482912",
+                    "edgeid": "fe1144e8-918f-4f90-962b-76fd6adc0f29",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "fdcbcaa6-78aa-4b6c-90b8-54f3d4d66019"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b3908-2017-11ee-9071-214dbb482912",
+                    "edgeid": "26f3abdc-e472-4dee-b5a2-402f01fcd387",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "75bfc094-64f3-4de9-a00a-36501ee59255"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b3902-2017-11ee-9071-214dbb482912",
+                    "edgeid": "36056449-8da1-4259-9808-f1f77b97882f",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "bd890cc4-1e7d-4f73-86f9-7e564701d072"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b3908-2017-11ee-9071-214dbb482912",
+                    "edgeid": "e82773f1-f750-4cb1-874b-f6ac5a69f435",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "56a9a8be-4dff-4cff-8468-2254a9a72534"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "780b3908-2017-11ee-9071-214dbb482912",
+                    "edgeid": "02ee9c79-752f-46d3-8bcb-535abe19532c",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "242c017a-fd13-4546-a176-031a073abde6"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f6360636-3574-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "a159f609-98e0-4b3a-8754-42a30340d002",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "fb9918c3-0f05-496e-aa2a-f4d4691676e5"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f6360636-3574-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "b248ce24-8284-4fc0-99bf-fa5c98d16b70",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "4a791e4c-ed53-4ef8-be6f-9114439557ae"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "f6360636-3574-11ee-8a8d-11afefc4bff7",
+                    "edgeid": "1913e7f4-fd33-47cf-b766-9820f80fc1ce",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "1baf82fe-c12a-4c1c-9ef5-8c101f95f3f9"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
+                    "edgeid": "10ff1bc0-e710-432b-83e0-a6e74d91bd97",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "02282c0b-5c99-4489-a329-709b85af830d"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
+                    "edgeid": "d91e52b4-8227-49fb-a7a0-1676a8960a54",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "e03d9302-8662-4bd3-8b3c-5dc2aacd39d5"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
+                    "edgeid": "ad9b91b3-5735-4929-8307-82862495ac12",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "b9763ff2-e4f8-4729-9fa1-e6ab89b514a6"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
+                    "edgeid": "8db5f1ad-d3e0-4ef6-846c-e2e7898e3478",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "30d40039-4811-4fa3-bf86-0e4e40fd0af5"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
+                    "edgeid": "c783c267-1c25-4d51-96c7-b988191019ea",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "386e021c-481e-4456-bbbb-21ede27dc3db"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
+                    "edgeid": "ec368f94-f8a5-4e1e-be46-313fd66feb9c",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "2953f318-e2e1-433a-a21c-1799c7a779dc"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
+                    "edgeid": "aae4a628-b80a-4e71-86ff-9e7e51b27cf1",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "7eee7dc8-ac11-4b36-8263-aef3f7bfdca8"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6db1-2019-11ee-9071-214dbb482912",
+                    "edgeid": "85049637-e86b-4903-8e26-db738bae8685",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "4d488d1b-686f-4468-9e7b-090164c81584"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "7eee7dc8-ac11-4b36-8263-aef3f7bfdca8",
+                    "edgeid": "7fa4a33a-9545-4972-aa16-34e8b315a0fc",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "fa1a6dbf-2019-11ee-9071-214dbb482912"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
+                    "edgeid": "20e9cb51-7855-42c0-b615-6fda1445193a",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "rangenode_id": "b41f2061-a1f1-4638-99f0-bc5723ba443c"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
+                    "edgeid": "2c1f2037-d462-4a2d-99af-6c6998b67c62",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "rangenode_id": "f891b264-3661-43b6-af1e-6ff609e454da"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
+                    "edgeid": "871fce4c-9384-47f9-9446-ca6bca2fbd90",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "b878c7fd-acc1-4254-8683-f2f1c2e13a39"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
+                    "edgeid": "c3a95687-baa3-4fcc-ad4d-c82f84a6ae53",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "66c75e63-3a23-4292-844c-478c1dbc259b"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
+                    "edgeid": "cce4ea79-e20c-4514-b8f8-adba5ed589c2",
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "rangenode_id": "d5711aa8-8977-4bd7-a6b4-04928c2d7a19"
                 }
             ],
             "functions_x_graphs": [
@@ -19488,7 +19801,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_label",
+                    "alias": "identifier_data_assignment_statement_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -19500,7 +19813,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_label",
+                    "name": "identifier_data_assignment_statement_label_1",
                     "nodegroup_id": "780b3902-2017-11ee-9071-214dbb482912",
                     "nodeid": "780b38fd-2017-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -19769,7 +20082,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_timespan_duration_name_language",
+                    "alias": "identifier_data_assignment_timespan_duration_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -19783,7 +20096,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_timespan_duration_name_language",
+                    "name": "identifier_data_assignment_timespan_duration_name_language_1",
                     "nodegroup_id": "780b3908-2017-11ee-9071-214dbb482912",
                     "nodeid": "780b390a-2017-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -19949,7 +20262,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_timespan_duration_name_content",
+                    "alias": "identifier_data_assignment_timespan_duration_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -19961,7 +20274,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_timespan_duration_name_content",
+                    "name": "identifier_data_assignment_timespan_duration_name_content_1",
                     "nodegroup_id": "780b3908-2017-11ee-9071-214dbb482912",
                     "nodeid": "780b3912-2017-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -20345,7 +20658,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_label",
+                    "alias": "identifier_data_assignment_statement_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -20357,7 +20670,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_label",
+                    "name": "identifier_data_assignment_statement_name_label_1",
                     "nodegroup_id": "780b391f-2017-11ee-9071-214dbb482912",
                     "nodeid": "780b3923-2017-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -20366,7 +20679,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_timespan_duration_name_label",
+                    "alias": "identifier_data_assignment_timespan_duration_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -20378,7 +20691,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_timespan_duration_name_label",
+                    "name": "identifier_data_assignment_timespan_duration_name_label_1",
                     "nodegroup_id": "780b3908-2017-11ee-9071-214dbb482912",
                     "nodeid": "780b3924-2017-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -20431,7 +20744,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "identifier_data_assignment_statement_name_language",
+                    "alias": "identifier_data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -20445,7 +20758,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "identifier_data_assignment_statement_name_language",
+                    "name": "identifier_data_assignment_statement_name_language_1",
                     "nodegroup_id": "780b391f-2017-11ee-9071-214dbb482912",
                     "nodeid": "780b3927-2017-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -25289,7 +25602,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "creation_identifier_type",
+                    "alias": "creation_identifier_type_1",
                     "config": {
                         "rdmCollection": "1fc06e2f-d87f-458d-9421-1566e1121885"
                     },
@@ -25303,7 +25616,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "creation_identifier_type",
+                    "name": "creation_identifier_type_1",
                     "nodegroup_id": "f6360636-3574-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f6360679-3574-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -25991,7 +26304,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "creation_identifier_content",
+                    "alias": "creation_identifier_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -26003,7 +26316,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "creation_identifier_content",
+                    "name": "creation_identifier_content_1",
                     "nodegroup_id": "f6360636-3574-11ee-8a8d-11afefc4bff7",
                     "nodeid": "f6360698-3574-11ee-8a8d-11afefc4bff7",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -28180,7 +28493,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_name_label",
+                    "alias": "data_assignment_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -28192,7 +28505,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_name_label",
+                    "name": "data_assignment_name_label_1",
                     "nodegroup_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
                     "nodeid": "fa1a6d9f-2019-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -28201,7 +28514,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_name_type",
+                    "alias": "data_assignment_name_type_1",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
                     },
@@ -28215,7 +28528,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_name_type",
+                    "name": "data_assignment_name_type_1",
                     "nodegroup_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
                     "nodeid": "fa1a6da0-2019-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -28224,7 +28537,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_name_content",
+                    "alias": "data_assignment_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -28236,7 +28549,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_name_content",
+                    "name": "data_assignment_name_content_1",
                     "nodegroup_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
                     "nodeid": "fa1a6da1-2019-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -28587,7 +28900,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_type",
+                    "alias": "data_assignment_statement_type_1",
                     "config": {
                         "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
                     },
@@ -28601,7 +28914,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_type",
+                    "name": "data_assignment_statement_type_1",
                     "nodegroup_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
                     "nodeid": "fa1a6db1-2019-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -28765,7 +29078,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_language",
+                    "alias": "data_assignment_statement_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -28779,7 +29092,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_language",
+                    "name": "data_assignment_statement_language_1",
                     "nodegroup_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
                     "nodeid": "fa1a6db9-2019-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -28830,7 +29143,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_label",
+                    "alias": "data_assignment_statement_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -28842,7 +29155,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_label",
+                    "name": "data_assignment_statement_label_1",
                     "nodegroup_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
                     "nodeid": "fa1a6dbc-2019-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -28897,7 +29210,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_type_metatype",
+                    "alias": "data_assignment_statement_type_metatype_1",
                     "config": {
                         "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
                     },
@@ -28911,7 +29224,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_type_metatype",
+                    "name": "data_assignment_statement_type_metatype_1",
                     "nodegroup_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
                     "nodeid": "fa1a6dbf-2019-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -29008,7 +29321,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_name_language",
+                    "alias": "data_assignment_statement_name_language_1",
                     "config": {
                         "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
                     },
@@ -29022,7 +29335,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_name_language",
+                    "name": "data_assignment_statement_name_language_1",
                     "nodegroup_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
                     "nodeid": "fa1a6dc4-2019-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
@@ -29054,7 +29367,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_name_label",
+                    "alias": "data_assignment_statement_name_label_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -29066,7 +29379,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_name_label",
+                    "name": "data_assignment_statement_name_label_1",
                     "nodegroup_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
                     "nodeid": "fa1a6dc6-2019-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -29075,7 +29388,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "data_assignment_statement_name_content",
+                    "alias": "data_assignment_statement_name_content_1",
                     "config": {},
                     "datatype": "string",
                     "description": null,
@@ -29087,7 +29400,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "data_assignment_statement_name_content",
+                    "name": "data_assignment_statement_name_content_1",
                     "nodegroup_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
                     "nodeid": "fa1a6dc7-2019-11ee-9071-214dbb482912",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
@@ -29119,6 +29432,733 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "data_assignment_statement_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_type_1",
+                    "nodegroup_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
+                    "nodeid": "fa1a6dc9-2019-11ee-9071-214dbb482912",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_content_1",
+                    "nodegroup_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
+                    "nodeid": "fa1a6dca-2019-11ee-9071-214dbb482912",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_language_1",
+                    "nodegroup_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
+                    "nodeid": "fa1a6dcb-2019-11ee-9071-214dbb482912",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_label",
+                    "nodegroup_id": "780b3902-2017-11ee-9071-214dbb482912",
+                    "nodeid": "1291b2ea-d5a8-4f4e-a682-5eb2da03d300",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_content_1",
+                    "nodegroup_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "nodeid": "b38f7f8b-69b3-4c76-a732-e1f70efdc98c",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_content_2",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_content_2",
+                    "nodegroup_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "nodeid": "bc419b8e-46b0-4b10-a081-809be67000cc",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_type_metatype_1",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_type_metatype_1",
+                    "nodegroup_id": "780b3902-2017-11ee-9071-214dbb482912",
+                    "nodeid": "7b0538ae-3cde-4f11-9355-ad0f95b67922",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_timespan_duration_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_timespan_duration_name_language",
+                    "nodegroup_id": "780b3908-2017-11ee-9071-214dbb482912",
+                    "nodeid": "242c017a-fd13-4546-a176-031a073abde6",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_content_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_content_1",
+                    "nodegroup_id": "780b3902-2017-11ee-9071-214dbb482912",
+                    "nodeid": "80707243-5ce2-4f54-a147-ad824b3ee748",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_timespan_duration_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_timespan_duration_name_content",
+                    "nodegroup_id": "780b3908-2017-11ee-9071-214dbb482912",
+                    "nodeid": "75bfc094-64f3-4de9-a00a-36501ee59255",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_language_1",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_language_1",
+                    "nodegroup_id": "780b3902-2017-11ee-9071-214dbb482912",
+                    "nodeid": "bd890cc4-1e7d-4f73-86f9-7e564701d072",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_label_2",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_label_2",
+                    "nodegroup_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "nodeid": "be21da54-faa4-4f98-8ce0-02f81ca595f4",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_label",
+                    "nodegroup_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "nodeid": "3b09a1e7-622b-48fa-ba2f-d0764091a660",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_timespan_duration_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_timespan_duration_name_label",
+                    "nodegroup_id": "780b3908-2017-11ee-9071-214dbb482912",
+                    "nodeid": "56a9a8be-4dff-4cff-8468-2254a9a72534",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_timespan_duration_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_timespan_duration_name_type_1",
+                    "nodegroup_id": "780b3908-2017-11ee-9071-214dbb482912",
+                    "nodeid": "fdcbcaa6-78aa-4b6c-90b8-54f3d4d66019",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_language",
+                    "nodegroup_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "nodeid": "2303da18-1b56-4d5c-9d12-82084eadf641",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_language_2",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_language_2",
+                    "nodegroup_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "nodeid": "da75f196-abe1-49a1-90bd-1cbdb4b36480",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_type_1",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_type_1",
+                    "nodegroup_id": "780b3902-2017-11ee-9071-214dbb482912",
+                    "nodeid": "fbd3393f-a9b9-47dc-b9d7-6d2c5ba8bcbd",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_type_2",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_type_2",
+                    "nodegroup_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "nodeid": "e9526e3b-e7fa-4c79-8ac8-60ff3b09d48c",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "identifier_data_assignment_statement_name_type_1",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "identifier_data_assignment_statement_name_type_1",
+                    "nodegroup_id": "780b391f-2017-11ee-9071-214dbb482912",
+                    "nodeid": "abb31ded-dde5-4e84-a032-182b3db03ea1",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_label_1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_label_1",
+                    "nodegroup_id": "f6360636-3574-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "fb9918c3-0f05-496e-aa2a-f4d4691676e5",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_type",
+                    "config": {
+                        "rdmCollection": "1fc06e2f-d87f-458d-9421-1566e1121885"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_type",
+                    "nodegroup_id": "f6360636-3574-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "1baf82fe-c12a-4c1c-9ef5-8c101f95f3f9",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "creation_identifier_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "creation_identifier_content",
+                    "nodegroup_id": "f6360636-3574-11ee-8a8d-11afefc4bff7",
+                    "nodeid": "4a791e4c-ed53-4ef8-be6f-9114439557ae",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_label",
+                    "nodegroup_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
+                    "nodeid": "02282c0b-5c99-4489-a329-709b85af830d",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_type",
+                    "config": {
+                        "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_type",
+                    "nodegroup_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
+                    "nodeid": "e03d9302-8662-4bd3-8b3c-5dc2aacd39d5",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_name_content",
+                    "nodegroup_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
+                    "nodeid": "b9763ff2-e4f8-4729-9fa1-e6ab89b514a6",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_type",
+                    "config": {
+                        "rdmCollection": "9103e619-ac38-4ffb-925f-042132761660"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_type",
+                    "nodegroup_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
+                    "nodeid": "7eee7dc8-ac11-4b36-8263-aef3f7bfdca8",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_language",
+                    "nodegroup_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
+                    "nodeid": "386e021c-481e-4456-bbbb-21ede27dc3db",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_label",
+                    "nodegroup_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
+                    "nodeid": "2953f318-e2e1-433a-a21c-1799c7a779dc",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_type_metatype",
+                    "config": {
+                        "rdmCollection": "fc169700-25de-4595-9460-54bc18a1e843"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_type_metatype",
+                    "nodegroup_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
+                    "nodeid": "4d488d1b-686f-4468-9e7b-090164c81584",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_language",
+                    "config": {
+                        "rdmCollection": "f9fe7635-4d70-4a23-b6f3-25492c3ca190"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_language",
+                    "nodegroup_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
+                    "nodeid": "b41f2061-a1f1-4638-99f0-bc5723ba443c",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_label",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_label",
+                    "nodegroup_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
+                    "nodeid": "f891b264-3661-43b6-af1e-6ff609e454da",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "data_assignment_statement_name_content",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "933ee880-b4b5-11ea-84f7-3af9d3b32b71",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "data_assignment_statement_name_content",
+                    "nodegroup_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
+                    "nodeid": "b878c7fd-acc1-4254-8683-f2f1c2e13a39",
+                    "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "data_assignment_statement_name_type",
                     "config": {
                         "rdmCollection": "025e8776-0e21-4f1a-b23e-02678178acd7"
@@ -29135,7 +30175,7 @@
                     "istopnode": false,
                     "name": "data_assignment_statement_name_type",
                     "nodegroup_id": "fa1a6dc1-2019-11ee-9071-214dbb482912",
-                    "nodeid": "fa1a6dc9-2019-11ee-9071-214dbb482912",
+                    "nodeid": "66c75e63-3a23-4292-844c-478c1dbc259b",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
@@ -29156,7 +30196,7 @@
                     "istopnode": false,
                     "name": "data_assignment_statement_content",
                     "nodegroup_id": "fa1a6daf-2019-11ee-9071-214dbb482912",
-                    "nodeid": "fa1a6dca-2019-11ee-9071-214dbb482912",
+                    "nodeid": "d5711aa8-8977-4bd7-a6b4-04928c2d7a19",
                     "ontologyclass": "http://www.w3.org/2001/XMLSchema#string",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P190_has_symbolic_content",
                     "sortorder": 0,
@@ -29179,7 +30219,7 @@
                     "istopnode": false,
                     "name": "data_assignment_name_language",
                     "nodegroup_id": "fa1a6d9e-2019-11ee-9071-214dbb482912",
-                    "nodeid": "fa1a6dcb-2019-11ee-9071-214dbb482912",
+                    "nodeid": "30d40039-4811-4fa3-bf86-0e4e40fd0af5",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E56_Language",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P72_has_language",
                     "sortorder": 0,


### PR DESCRIPTION
## Summary
This PR addresses multiple constraint violations that prevented loading Arches 7.6 packages into Arches 8.0.

### Changes
- Fixed duplicate node IDs (151 nodes)
- Fixed duplicate node names within cards (141 names)
- Fixed duplicate aliases within graphs (141 aliases)
- Fixed orphaned nodegroup references (2 removals in Provenance Activity)
- Removed invalid concept default values (12 fields across 9 models)

### Testing
Tested by loading package into Arches 8.0 instance.